### PR TITLE
Add upload siad support

### DIFF
--- a/setup-scripts/README.md
+++ b/setup-scripts/README.md
@@ -55,10 +55,28 @@ done so.
 
 To enable the service: `systemctl --user enable siad.service`
 
+### Running 2 siad instances
+In some cases, portal operators may want to run 2 `siad` nodes on the same
+server. One node to prioritize downloads and one to prioritze uploads The
+scripts here also do the initial setup for a 2nd `siad` instance running as a
+systemd service `siad-upload.service` in the `~/siad-upload/` directory with
+environment variables in `sia-upload.env`. You must fill out the correct values
+for those environment variables.
+
+The `bashrc` file in this repository  also provides an alias `siac-upload` that
+loads the correct environment variables and sets the correct ports to interact
+with the 2nd `siad` node.
+
+`siac` is used to operate node 1, and `siac-upload` is used to operate node 2.
+
+To enable the 2nd service: `systemctl --user enable siad-upload.service`
+
 ### Useful Commands
 
 To start the service: `systemctl --user start siad`
+
 To stop it: `systemctl --user stop siad`
+
 To check the status of it: `systemctl --user status siad`
 
 To check standard err/standard out: `journalctl --user-unit siad`

--- a/setup-scripts/bashrc
+++ b/setup-scripts/bashrc
@@ -116,3 +116,5 @@ export PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/usr/local/
 set -o allexport
 source ~/.sia/sia.env
 set +o allexport
+
+alias siac-upload="source ~/.sia/source-upload.sh; siac --addr 'localhost:9970'"

--- a/setup-scripts/setup.sh
+++ b/setup-scripts/setup.sh
@@ -65,10 +65,13 @@ cd ../
 yarn
 yarn build
 
-# Enable the systemd service
+# Setup systemd files
 cd $cwd
 mkdir -p ~/.config/systemd/user
 cp siad.service ~/.config/systemd/user/siad.service
+cp siad-upload.service ~/.config/systemd/user/siad-upload.service
 
+# Setup files for storing environment variables
 mkdir -p ~/.sia
 cp sia.env ~/.sia/
+cp sia.env ~/.sia/sia-upload.env

--- a/setup-scripts/siad-upload.service
+++ b/setup-scripts/siad-upload.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=siad-upload
+
+[Service]
+Type=simple
+WorkingDirectory=/home/user/siad-upload
+EnvironmentFile=/home/user/.sia/sia-upload.env
+ExecStart=/home/user/go/bin/siad --api-addr "localhost:9970" --host-addr ":9972" --rpc-addr ":9971"
+ExecStop=/home/user/go/bin/siac --api-addr "localhost:9970" --host-addr ":9972" --rpc-addr ":9971" stop
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/setup-scripts/source-upload.sh
+++ b/setup-scripts/source-upload.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+set -e
+
+set -o allexport
+source ~/.sia/sia-upload.env
+set +o allexport


### PR DESCRIPTION
Add a separate systemd file for a second siad used for uploads

Adds bash alias `siac-upload` that uses `siac` for the upload node