### PR TITLE
upload progress status

### DIFF
--- a/setup-scripts/skynet-nginx.conf
+++ b/setup-scripts/skynet-nginx.conf
@@ -22,7 +22,8 @@ server {
 		# proxy this call to siad endpoint (make sure the ip is correct)
 		proxy_pass http://127.0.0.1:9980;
 		proxy_set_header Expect $http_expect;
-		proxy_set_header Access-Control-Allow-Origin: *;
+		add_header Access-Control-Allow-Origin *;
+		proxy_hide_header Access-Control-Allow-Origin;
 		# make sure to override user agent header - siad requirement
 		proxy_set_header User-Agent: Sia-Agent; 
 		# replace BASE64_AUTHENTICATION with base64 encoded <user>:<password>

--- a/src/components/UploadFile/UploadFile.js
+++ b/src/components/UploadFile/UploadFile.js
@@ -4,7 +4,7 @@ import "./UploadFile.scss";
 import { LoadingSpinner } from "../";
 import { File, FileCheck, FileError, Copy } from "../../svg";
 
-export default function UploadFile({ file, url, status }) {
+export default function UploadFile({ file, url, status, progress }) {
   const [copied, setCopied] = useState(false);
   const urlRef = useRef(null);
 
@@ -43,7 +43,7 @@ export default function UploadFile({ file, url, status }) {
       <div className="upload-file-text">
         <h3>{file.name}</h3>
         <p>
-          {status === "uploading" && "Uploading..."}
+          {status === "uploading" && (progress ? `Uploading ${Math.round(progress * 100)}%` : "Uploading...")}
           {status === "processing" && "Processing..."}
           {status === "error" && <span className="red-text">Error processing file.</span>}
           {status === "complete" && (
@@ -78,5 +78,6 @@ UploadFile.propTypes = {
     name: PropTypes.string.isRequired
   }),
   status: PropTypes.string.isRequired,
-  url: PropTypes.string
+  url: PropTypes.string,
+  progress: PropTypes.number
 };


### PR DESCRIPTION
- added uploading percentage indicator
- added support for "processing" state between last uploaded byte and api response
- resolved (at least temporarily) cors issue with axios

case study:

case 1:
- no `add_header Access-Control-Allow-Origin: *;`
- no `proxy_hide_header Access-Control-Allow-Origin: *;`
- no `proxy_set_header Access-Control-Allow-Origin: *;`

`No 'Access-Control-Allow-Origin' header is present on the requested resource.`

case 2: 
- added `add_header Access-Control-Allow-Origin: *;`
- no `proxy_hide_header Access-Control-Allow-Origin: *;`
- no `proxy_set_header Access-Control-Allow-Origin: *;`

`The 'Access-Control-Allow-Origin' header contains multiple values '*, *', but only one is allowed.`

case 3:
- no `add_header Access-Control-Allow-Origin: *;`
- no `proxy_hide_header Access-Control-Allow-Origin: *;`
- added `proxy_set_header Access-Control-Allow-Origin: *;`

`No 'Access-Control-Allow-Origin' header is present on the requested resource.`

case 4: 
- added `add_header Access-Control-Allow-Origin: *;`
- no `proxy_hide_header Access-Control-Allow-Origin: *;`
- added `proxy_set_header Access-Control-Allow-Origin: *;`

`The 'Access-Control-Allow-Origin' header contains multiple values '*, *', but only one is allowed.`

case 5: 
- added `add_header Access-Control-Allow-Origin: *;`
- added `proxy_hide_header Access-Control-Allow-Origin: *;`
- no `proxy_set_header Access-Control-Allow-Origin: *;`

works 🎉 

