### PR TITLE
[WIP] Add /version endpoint

### DIFF
--- a/setup-scripts/skynet-nginx.conf
+++ b/setup-scripts/skynet-nginx.conf
@@ -16,6 +16,14 @@ server {
 		root /home/user/skynet-webportal/public; # path to root of index.html
 	}
 
+	location /version {
+		# make sure to override user agent header - siad requirement
+		proxy_set_header User-Agent: Sia-Agent;
+
+		# proxy pass to the /daemon/version endpoint
+		proxy_pass http://127.0.0.1:9980/daemon/version;
+	}
+
 	location /skynet/skyfile/ {
 		client_max_body_size 1000M; # make sure to limit the size of upload to a sane value
 		proxy_read_timeout 600;


### PR DESCRIPTION
This MR adds a `/version` route which was suggested by someone in the community.
Please note this returns the version of the "download-siad".
It's live on https://siasky.dev/version, you can see the output there.