### PR TITLE
Expose Skynet-File-Metadata

### DIFF
--- a/setup-scripts/skynet-nginx.conf
+++ b/setup-scripts/skynet-nginx.conf
@@ -39,6 +39,9 @@ server {
 		# make sure to override user agent header - siad requirement
 		proxy_set_header User-Agent: Sia-Agent;
 		
+		# make sure the Skynet-File-Metadata header gets exposed in the response
+		add_header Access-Control-Expose-Headers skynet-file-metadata;
+
 		# if you are expecting large headers (ie. Skynet-Skyfile-Metadata), tune these values to your needs
 		#proxy_buffer_size 128k;
 		#proxy_buffers 4 128k;
@@ -52,6 +55,9 @@ server {
 		proxy_set_header Access-Control-Allow-Origin: *;
 		# make sure to override user agent header - siad requirement
 		proxy_set_header User-Agent: Sia-Agent;
+
+		# make sure the Skynet-File-Metadata header gets exposed in the response
+		add_header Access-Control-Expose-Headers skynet-file-metadata;
 
 		# if you are expecting large headers (ie. Skynet-Skyfile-Metadata), tune these values to your needs
 		#proxy_buffer_size 128k;


### PR DESCRIPTION
Update Nginx so our Skynet-File-Metadata header is properly exposed. Was hidden, only when making the request from a browser though, which is why we did not notice.
