### PR TITLE
uploaded files are stored in random nested directories

### DIFF
--- a/setup-scripts/skynet-nginx.conf
+++ b/setup-scripts/skynet-nginx.conf
@@ -20,10 +20,6 @@ server {
 	client_body_timeout 5s;
 	client_header_timeout 5s;
 
-	# Auto generate a uuid for each file. This means users are able to upload
-	# Skyfiles without having to provide a uuid
-	rewrite ^/skynet/skyfile/?$ /skynet/skyfile/$request_id$1;
-
 	# NOTE: make sure to enable any additional configuration you might need like gzip
 
 	location / {
@@ -56,10 +52,22 @@ server {
 		proxy_pass http://127.0.0.1:9980/skynet/stats;
 	}
 
-	location /skynet/skyfile/ {
+	location /skynet/skyfile {
 		limit_conn uploads_by_ip 10; # ddos protection: max 10 uploads at a time
 		client_max_body_size 1000M; # make sure to limit the size of upload to a sane value
 		proxy_read_timeout 600;
+
+		# Extract 3 sets of 2 characters from $request_id and assign to $dir1, $dir2, $dir3
+		# respectfully. The rest of the $request_id is going to be assigned to $dir4.
+		# We use those variables to automaticallygenerate unique path for uploaded file, yet 
+		# we want to limit the number of folders on one directory level so we create nested path.
+		# Example path result: /af/24/9b/c5ec894920ccc45634dc9a8065
+		if ($request_id ~* "(\w{2})(\w{2})(\w{2})(\w+)") {
+			set $dir1 $1;
+			set $dir2 $2;
+			set $dir3 $3;
+			set $dir4 $4;
+		}
 
 		# proxy this call to siad endpoint (make sure the ip is correct)
 		#
@@ -70,7 +78,7 @@ server {
 		# siad setup, make sure only the download portal runs in 'portal mode'.
 		# The upload siad can be run in normal mode. Set the port to '9980' if
 		# you do not want to run your portal in the double siad setup.
-		proxy_pass http://127.0.0.1:9970;
+		proxy_pass http://127.0.0.1:9970/skynet/skyfile/$dir1/$dir2/$dir3/$dir4;
 
 		proxy_set_header Expect $http_expect;
 		add_header Access-Control-Allow-Origin *;

--- a/setup-scripts/skynet-nginx.conf
+++ b/setup-scripts/skynet-nginx.conf
@@ -59,8 +59,9 @@ server {
 
 		# Extract 3 sets of 2 characters from $request_id and assign to $dir1, $dir2, $dir3
 		# respectfully. The rest of the $request_id is going to be assigned to $dir4.
-		# We use those variables to automaticallygenerate unique path for uploaded file, yet 
-		# we want to limit the number of folders on one directory level so we create nested path.
+		# We use those variables to automatically generate a unique path for the uploaded file.
+		# This ensures that not all uploaded files end up in the same directory, which is something
+		# that causes performance issues in the renter.
 		# Example path result: /af/24/9b/c5ec894920ccc45634dc9a8065
 		if ($request_id ~* "(\w{2})(\w{2})(\w{2})(\w+)") {
 			set $dir1 $1;


### PR DESCRIPTION
To limit number of files on one directory level (currently root level) we split `$request_id` into 3 two-character parts and one string from what's left. Then we pass it as a path (uuid) to `/skynet/skyfile` endpoint instead of passing the `$request_id` straight up.

Example:

- `request_id`: `af249bc5ec894920ccc45634dc9a8065` 
- generated path `af/24/9b/c5ec894920ccc45634dc9a8065`
- final endpoint call `POST /skynet/skyfile/af/24/9b/c5ec894920ccc45634dc9a8065`