### PR TITLE
fix whitespace encoding for directories

### DIFF
--- a/setup-scripts/skynet-nginx.conf
+++ b/setup-scripts/skynet-nginx.conf
@@ -86,10 +86,13 @@ server {
 	location ~ "^/([a-zA-Z0-9-_]{46}(/.*)?)$" {
 		limit_conn downloads_by_ip 10; # ddos protection: max 10 downloads at a time
 
+		# we need to explicitly use set directive here because $1 will contain the skylink with
+		# decoded whitespaces and set will re-encode it for us before passing it to proxy_pass
+		set $skylink $1;
+
 		proxy_read_timeout 600;
-		# proxy this call to siad /skynet/skylink/ endpoint (make sure the ip is
-		# correct)
-		proxy_pass http://127.0.0.1:9980/skynet/skylink/$1$is_args$args;
+		# proxy this call to siad /skynet/skylink/ endpoint (make sure the ip is correct)
+		proxy_pass http://127.0.0.1:9980/skynet/skylink/$skylink$is_args$args;
 		proxy_set_header Access-Control-Allow-Origin: *;
 		# make sure to override user agent header - siad requirement
 		proxy_set_header User-Agent: Sia-Agent;
@@ -111,11 +114,14 @@ server {
 	location ~ "^/file/([a-zA-Z0-9-_]{46}(/.*)?)$" {
 		limit_conn downloads_by_ip 10; # ddos protection: max 10 downloads at a time
 
+		# we need to explicitly use set directive here because $1 will contain the skylink with
+		# decoded whitespaces and set will re-encode it for us before passing it to proxy_pass
+		set $skylink $1;
+
 		proxy_read_timeout 600;
-		# proxy this call to siad /skunet/skylink/ endpoint (make sure the ip is
-		# correct) this alias also adds attachment=true url param to force
-		# download the file
-		proxy_pass http://127.0.0.1:9980/skynet/skylink/$1?attachment=true&$args;
+		# proxy this call to siad /skunet/skylink/ endpoint (make sure the ip is correct)
+		# this alias also adds attachment=true url param to force download the file
+		proxy_pass http://127.0.0.1:9980/skynet/skylink/$skylink?attachment=true&$args;
 		proxy_set_header Access-Control-Allow-Origin: *;
 		# make sure to override user agent header - siad requirement
 		proxy_set_header User-Agent: Sia-Agent;

--- a/setup-scripts/skynet-nginx.conf
+++ b/setup-scripts/skynet-nginx.conf
@@ -119,7 +119,7 @@ server {
 		set $skylink $1;
 
 		proxy_read_timeout 600;
-		# proxy this call to siad /skunet/skylink/ endpoint (make sure the ip is correct)
+		# proxy this call to siad /skynet/skylink/ endpoint (make sure the ip is correct)
 		# this alias also adds attachment=true url param to force download the file
 		proxy_pass http://127.0.0.1:9980/skynet/skylink/$skylink?attachment=true&$args;
 		proxy_set_header Access-Control-Allow-Origin: *;


### PR DESCRIPTION
https://stackoverflow.com/questions/8838905/how-to-avoid-nginx-to-replace-20-by-whitespace-when-using-as-a-proxy-proxy-pas

closes #190 