### PR TITLE
do not match empty skyfile path

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -89,7 +89,7 @@ server {
 		proxy_pass http://siad-upload/skynet/skyfile/$dir1/$dir2/$dir3/$dir4$is_args$args;
 	}
 	
-	location ~ "/skynet/skyfile/(.*)" {
+	location ~ "/skynet/skyfile/(.+)" {
 		limit_conn uploads_by_ip 10; # ddos protection: max 10 uploads at a time
 		client_max_body_size 1000M; # make sure to limit the size of upload to a sane value
 		proxy_read_timeout 600;


### PR DESCRIPTION
Fix regression that prevents POST to /skynet/skyfile/ (with trailing slash).
Verify on `_A6d-2CpM2OQ-7m5NPAYW830NdzC3wGydFzzd-KnHXhwJA/index.html`.

Closes #293 