### PR TITLE
Use a clearer log message and add some debug output.

### DIFF
--- a/setup-scripts/log-checker.py
+++ b/setup-scripts/log-checker.py
@@ -77,13 +77,20 @@ async def check_docker_logs():
     std_out, std_err = proc.communicate()
 
     if len(std_err) > 0:
+        # Trim the error log to under 1MB.
+        one_mb = 1024*1024
+        if len(std_err) > one_mb:
+            pos = std_err.find("\n", -one_mb)
+            std_err = std_err[pos+1:]
+        upload_name = "{}-{}-{}-{}-{}:{}:{}_err.log".format(container_name, time.year, time.month, time.day, time.hour, time.minute, time.second)
+        await send_msg(client, "Error(s) found in log!", file=discord.File(io.BytesIO(std_err.encode()), filename=upload_name), force_notify=True)
         # Send at most 1900 characters of logs, rounded down to the nearest new line.
         # This is a limitation in the size of Discord messages - they can be at most
         # 2000 characters long (and we send some extra characters before the error log).
         if len(std_err) > 1900:
             pos = std_err.find("\n", -1900)
             std_err = std_err[pos+1:]
-        await send_msg(client, "Error(s) found in log:\n{}".format(std_err), force_notify=True)
+        await send_msg(client, "Error(s) preview:\n{}".format(std_err), force_notify=True)
         return
 
     # If there are any critical errors. upload the whole log file.

--- a/setup-scripts/log-checker.py
+++ b/setup-scripts/log-checker.py
@@ -77,7 +77,13 @@ async def check_docker_logs():
     std_out, std_err = proc.communicate()
 
     if len(std_err) > 0:
-        await send_msg(client, "Error(s) found in log: {}".format(std_err), force_notify=True)
+        # Send at most 1900 characters of logs, rounded down to the nearest new line.
+        # This is a limitation in the size of Discord messages - they can be at most
+        # 2000 characters long (and we send some extra characters before the error log).
+        if len(std_err) > 1900:
+            pos = std_err.find("\n", -1900)
+            std_err = std_err[pos+1:]
+        await send_msg(client, "Error(s) found in log:\n{}".format(std_err), force_notify=True)
         return
 
     # If there are any critical errors. upload the whole log file.


### PR DESCRIPTION
Use a clearer log message, so we know that we found errors in the log rather than failing to read the logs.

Add some debug output for the times when we run the commands locally.

Limit the size of messages sent to Discord to 2000 characters. I chose to send the trailing 1900 characters of error log instead of dumping a file because that allows an easy cursory look in order to see whether it's an important error or small transient issue that will self-resolve. We can't use this approach for siad criticals because all of them are important by default.