### PR TITLE
Check system load

### DIFF
--- a/setup-scripts/log-checker.py
+++ b/setup-scripts/log-checker.py
@@ -55,9 +55,9 @@ async def check_load_average():
     uptime_string = os.popen("uptime").read().strip()
     # pattern = ""
     if sys.platform == "Darwin":
-        pattern = "^.*load averages: (\d*\.\d*) \d*\.\d* \d*\.\d*$"
+        pattern = "^.*load averages: \d*\.\d* \d*\.\d* (\d*\.\d*)$"
     else:
-        pattern = "^.*load average: (\d*\.\d*), \d*\.\d*, \d*\.\d*$"
+        pattern = "^.*load average: \d*\.\d*, \d*\.\d*, (\d*\.\d*)$"
     load_av = re.match(pattern, uptime_string).group(1)
     if float(load_av) > 10:
         await send_msg(client, "High system load detected: `{}`".format(uptime_string), force_notify=True)

--- a/setup-scripts/log-checker.py
+++ b/setup-scripts/log-checker.py
@@ -60,7 +60,7 @@ async def check_load_average():
         pattern = "^.*load average: \d*\.\d*, \d*\.\d*, (\d*\.\d*)$"
     load_av = re.match(pattern, uptime_string).group(1)
     if float(load_av) > 10:
-        await send_msg(client, "High system load detected: `{}`".format(uptime_string), force_notify=True)
+        await send_msg(client, "High system load detected: `uptime: {}`".format(uptime_string), force_notify=True)
 
 # check_docker_logs checks the docker logs by filtering on the docker image name
 async def check_docker_logs():


### PR DESCRIPTION
Extend the `log-checker` script to also keep an eye on the system load and report in Discord if it exceeds 10.

The value 10 was picked more or less at random. If anyone has a good reason to use another value, I'm fully open to that.

I'm using the 15 minute average, so short spikes won't trigger this. The script is run once per 8 hours, so we can't claim to monitor short spikes anyway. This is only intended to detect long-running problems.