### PR TITLE
Ensure the log checker process exits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,4 @@ docker/data
 # Cache files
 __pycache__
 /.idea/
-/venv/
+/venv*

--- a/setup-scripts/funds-checker.py
+++ b/setup-scripts/funds-checker.py
@@ -20,7 +20,7 @@ async def exit_after(delay):
 @client.event
 async def on_ready():
     await run_checks()
-    asyncio.create_task(exit_after(30))
+    asyncio.create_task(exit_after(3))
     await client.close()
 
 

--- a/setup-scripts/funds-checker.py
+++ b/setup-scripts/funds-checker.py
@@ -5,7 +5,7 @@ health-checker runs simple health checks on a portal node using the siad API and
 dispatches messages to a Discord channel.
 """
 
-import discord, traceback, asyncio
+import discord, traceback, asyncio, os
 from bot_utils import setup, send_msg, siad, sc_precision
 
 bot_token = setup()
@@ -14,7 +14,7 @@ client = discord.Client()
 
 async def exit_after(delay):
     await asyncio.sleep(delay)
-    exit(0)
+    os._exit(0)
 
 
 @client.event
@@ -74,5 +74,6 @@ async def check_health():
 
     # Send an informational heartbeat if all checks passed.
     await send_msg(client, "Health checks passed:\n{} \n{}".format(balance_msg, alloc_msg))
+
 
 client.run(bot_token)

--- a/setup-scripts/log-checker.py
+++ b/setup-scripts/log-checker.py
@@ -28,14 +28,13 @@ client = discord.Client()
 # exit_after kills the script if it hasn't exited on its own after `delay` seconds
 async def exit_after(delay):
     await asyncio.sleep(delay)
-    exit(0)
+    sys.exit(0)
 
 
 @client.event
 async def on_ready():
     await run_checks()
-    asyncio.create_task(exit_after(30))
-    await client.close()
+    asyncio.create_task(exit_after(3))
 
 
 async def run_checks():
@@ -71,12 +70,6 @@ async def check_docker_logs():
     if len(sys.argv) > 2:
         container_name = sys.argv[2]
 
-    # Get the container id for siad.
-    cmd = 'docker ps -q --filter name=^{}$'.format(container_name)
-    print("[DEBUG] will run `{}`".format(cmd))
-    stream = os.popen(cmd)
-    image_id = stream.read().strip()
-
     # Get the number of hours to look back in the logs or use 1 as default.
     check_hours = DEFAULT_CHECK_INTERVAL
     if len(sys.argv) > 3:
@@ -87,8 +80,8 @@ async def check_docker_logs():
     time_string = "{}h".format(check_hours)
 
     # Read the logs.
-    print("[DEBUG] Will run `docker logs --since {} {}`".format(time_string, image_id))
-    proc = Popen(["docker", "logs", "--since", time_string, image_id], stdin=PIPE, stdout=PIPE, stderr=PIPE, text=True)
+    print("[DEBUG] Will run `docker logs --since {} {}`".format(time_string, container_name))
+    proc = Popen(["docker", "logs", "--since", time_string, container_name], stdin=PIPE, stdout=PIPE, stderr=PIPE, text=True)
     std_out, std_err = proc.communicate()
 
     if len(std_err) > 0:
@@ -109,7 +102,7 @@ async def check_docker_logs():
         return
 
     # If there are any critical errors. upload the whole log file.
-    if "Critical" in std_out or "panic" in std_out:
+    if 'Critical' in std_out or 'panic' in std_out:
         upload_name = "{}-{}-{}-{}-{}:{}:{}.log".format(container_name, time.year, time.month, time.day, time.hour, time.minute, time.second)
         await send_msg(client, "Critical error found in log!", file=discord.File(io.BytesIO(std_out.encode()), filename=upload_name), force_notify=True)
         return
@@ -118,5 +111,6 @@ async def check_docker_logs():
     pretty_before = time.strftime("%I:%M%p")
     pretty_now = now.strftime("%I:%M%p")
     await send_msg(client, "No critical warnings in log from `{}` to `{}`".format(pretty_before, pretty_now))
+
 
 client.run(bot_token)

--- a/setup-scripts/log-checker.py
+++ b/setup-scripts/log-checker.py
@@ -28,7 +28,7 @@ client = discord.Client()
 # exit_after kills the script if it hasn't exited on its own after `delay` seconds
 async def exit_after(delay):
     await asyncio.sleep(delay)
-    sys.exit(0)
+    os._exit(0)
 
 
 @client.event


### PR DESCRIPTION
We're experiencing an issue where log checker processes won't exit and will consume a lot of CPU. This MR addresses that.

Changes:
- Simply do not call `client.close()`. This call hangs the interpreter. I don't why and I've spent too long trying to figure it out. If someone else with better Python knowledge can solve this, please do.
- Don't bother getting the docker image id - calling `docker logs` also works directly with the container name.
