### PR TITLE
fix byte range caching

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -194,6 +194,14 @@ server {
 		proxy_cache_valid 200 1440m;
 		proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option
 		add_header X-Proxy-Cache $upstream_cache_status;
+
+		# byte range caching
+		slice 1m;
+		proxy_set_header Range $slice_range;
+		proxy_cache_lock on;
+		proxy_cache_lock_timeout 0s;
+		proxy_cache_lock_age 200s;
+		proxy_cache_use_stale updating;
 	}
 
 	location ~ "^/file/([a-zA-Z0-9-_]{46}(/.*)?)$" {
@@ -220,5 +228,13 @@ server {
 		proxy_cache_valid 200 1440m;
 		proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option
 		add_header X-Proxy-Cache $upstream_cache_status;
+
+		# byte range caching
+		slice 1m;
+		proxy_set_header Range $slice_range;
+		proxy_cache_lock on;
+		proxy_cache_lock_timeout 0s;
+		proxy_cache_lock_age 200s;
+		proxy_cache_use_stale updating;
 	}
 }

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -174,6 +174,7 @@ server {
 	location ~ "^/([a-zA-Z0-9-_]{46}(/.*)?)$" {
 		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/proxy-buffer;
+		include /etc/nginx/conf.d/include/proxy-cache-downloads;
 
 		limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
 		add_header Cache-Control "public, max-age=86400"; # allow consumer to cache response
@@ -186,27 +187,12 @@ server {
 		proxy_set_header User-Agent: Sia-Agent;
 		# proxy this call to siad /skynet/skylink/ endpoint (make sure the ip is correct)
 		proxy_pass http://siad/skynet/skylink/$skylink$is_args$args;
-
-		# cache frequent (> 10) downloads for 24 hours
-		proxy_cache skynet;
-		proxy_cache_key $uri;
-		proxy_cache_min_uses 10;
-		proxy_cache_valid 200 1440m;
-		proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option
-		add_header X-Proxy-Cache $upstream_cache_status;
-
-		# byte range caching
-		slice 1m;
-		proxy_set_header Range $slice_range;
-		proxy_cache_lock on;
-		proxy_cache_lock_timeout 0s;
-		proxy_cache_lock_age 200s;
-		proxy_cache_use_stale updating;
 	}
 
 	location ~ "^/file/([a-zA-Z0-9-_]{46}(/.*)?)$" {
 		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/proxy-buffer;
+		include /etc/nginx/conf.d/include/proxy-cache-downloads;
 
 		limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
 		add_header Cache-Control "public, max-age=86400"; # allow consumer to cache response
@@ -220,21 +206,5 @@ server {
 		# proxy this call to siad /skynet/skylink/ endpoint (make sure the ip is correct)
 		# this alias also adds attachment=true url param to force download the file
 		proxy_pass http://siad/skynet/skylink/$skylink?attachment=true&$args;
-		
-		# cache frequent (> 10) downloads for 24 hours
-		proxy_cache skynet;
-		proxy_cache_key $uri;
-		proxy_cache_min_uses 10;
-		proxy_cache_valid 200 1440m;
-		proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option
-		add_header X-Proxy-Cache $upstream_cache_status;
-
-		# byte range caching
-		slice 1m;
-		proxy_set_header Range $slice_range;
-		proxy_cache_lock on;
-		proxy_cache_lock_timeout 0s;
-		proxy_cache_lock_age 200s;
-		proxy_cache_use_stale updating;
 	}
 }

--- a/docker/nginx/conf.d/include/proxy-cache-downloads
+++ b/docker/nginx/conf.d/include/proxy-cache-downloads
@@ -2,7 +2,7 @@ proxy_cache skynet;
 slice 1m;
 proxy_http_version 1.1; # upgrade if necessary because 1.0 does not support byte-range requests
 proxy_set_header Range $slice_range; # pass slice range to proxy
-proxy_cache_key $uri$is_args$args$slice_range; # include $slice_range in the cache key
+proxy_cache_key $uri$slice_range; # include $slice_range in the cache key
 proxy_cache_min_uses 3; # cache responses after 3 requests of the same file
 proxy_cache_valid 200 206 24h; # cache 200 and 206 responses for 24 hours
 proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option

--- a/docker/nginx/conf.d/include/proxy-cache-downloads
+++ b/docker/nginx/conf.d/include/proxy-cache-downloads
@@ -1,0 +1,9 @@
+proxy_cache skynet;
+slice 1m;
+proxy_http_version 1.1; # upgrade if necessary because 1.0 does not support byte-range requests
+proxy_set_header Range $slice_range; # pass slice range to proxy
+proxy_cache_key $uri$is_args$args$slice_range; # include $slice_range in the cache key
+proxy_cache_min_uses 3; # cache responses after 3 requests of the same file
+proxy_cache_valid 200 206 24h; # cache 200 and 206 responses for 24 hours
+proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option
+add_header X-Proxy-Cache $upstream_cache_status; # add response header to indicate cache hits and misses


### PR DESCRIPTION
This fixes video streaming again.
Instead of trying to download the whole file to put it in the cache, nginx will just download ranges of 1MB now.
If multiple requests try to access an uncached slice at the same time, only the first one will fetch the whole sector. The remaining ones will be forwarded to siad directly.