### PR TITLE
drop health-check endpoint from access.log

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -108,6 +108,8 @@ server {
 	location /health-check {
 		include /etc/nginx/conf.d/include/cors;
 
+		access_log off; # do not log traffic to health-check endpoint
+
 		proxy_pass http://health-check:3100;
 	}
 


### PR DESCRIPTION
Do not log /health-check access in access.log - 75% of our access.log file are just the health-checks accessed by AWS