### PR TITLE
Make the time comparisons in the health checker timezone-aware.

### DIFF
--- a/setup-scripts/health-checker.py
+++ b/setup-scripts/health-checker.py
@@ -159,8 +159,10 @@ async def check_health():
         await send_msg(client, message, file=file, force_notify=notifyTeam)
         return
 
-    # Send an informational heartbeat if all checks passed.
-    await send_msg(client, "Health checks passed: {}/{}\n".format(passed_checks, checks))
+    # Send an informational heartbeat if all checks passed but only if it's in
+    # the first CHECK_HOURS hours of the day, essentially the first call.
+    if datetime.now().hour < CHECK_HOURS:
+        await send_msg(client, "Health checks passed: {}/{}\n".format(passed_checks, checks))
 
 
 client.run(bot_token)

--- a/setup-scripts/setup-health-check-scripts.sh
+++ b/setup-scripts/setup-health-check-scripts.sh
@@ -5,7 +5,7 @@ set -e # exit on first error
 sudo apt-get update
 sudo apt-get -y install python3-pip
 
-pip3 install discord.py python-dotenv requests
+pip3 install discord.py python-dotenv requests pytz tzlocal
 
 fundsCheck="0 0,8,16 * * * /home/user/skynet-webportal/setup-scripts/funds-checker.py /home/user/skynet-webportal/.env"
 logsCheck="0 0,8,16 * * * /home/user/skynet-webportal/setup-scripts/log-checker.py /home/user/skynet-webportal/.env sia 8"


### PR DESCRIPTION
In the health checker we fetch the full records for the health status of the node. Then we filter the records for the last N hours, where N is either 1 (default) or whatever is passed as parameter to the script. The we scan those and report what we've found.

The issue is that the timestamps provided by the `/health-check` endpoint are UTC-based (as they should) but the local time we get from `datetime.datetime.now()` is not. And those cannot be directly compared in Python. Hence the complexity of converting them to timezone-aware (offset-aware) versions by calling `pytz.utc.localize(time_unaware)`.

Also, we want to report on the "happy case" (no errors found) only once a day.