### PR TITLE
always use request_id path

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -151,25 +151,6 @@ server {
 		# proxy this call to siad endpoint (make sure the ip is correct)
 		proxy_pass http://siad/skynet/skyfile/$dir1/$dir2/$dir3/$dir4$is_args$args;
 	}
-	
-	location ~ "/skynet/skyfile/(.+)" {
-		include /etc/nginx/conf.d/include/cors;
-		include /etc/nginx/conf.d/include/sia-auth;
-
-		limit_conn uploads_by_ip 10; # ddos protection: max 10 uploads at a time
-		client_max_body_size 1000M; # make sure to limit the size of upload to a sane value
-		proxy_read_timeout 600;
-		proxy_request_buffering off; # stream uploaded files through the proxy as it comes in
-		proxy_set_header Expect $http_expect;
-		proxy_set_header User-Agent: Sia-Agent;
-
-		# we need to explicitly use set directive here because $1 will contain the siapath with
-		# decoded whitespaces and set will re-encode it for us before passing it to proxy_pass
-		set $siapath $1;
-
-		# proxy this call to siad endpoint (make sure the ip is correct)
-		proxy_pass http://siad/skynet/skyfile/$siapath$is_args$args;
-	}
 
 	location ~ "^/([a-zA-Z0-9-_]{46}(/.*)?)$" {
 		include /etc/nginx/conf.d/include/cors;


### PR DESCRIPTION
It does not make sense for siasky.net (or any public portal) to allow specifying a path for a file upload. Some public portal owners already disabled that. By removing the block responsible for that, block that uses `$request_id` will pick these requests from now on and properly proxy with random path.