### PR TITLE
update db before reading it in api

### DIFF
--- a/packages/health-check/src/index.js
+++ b/packages/health-check/src/index.js
@@ -6,6 +6,7 @@ if (!process.env.PORTAL_URL) {
 
 const express = require("express");
 const bodyparser = require("body-parser");
+const db = require("./db");
 
 require("./schedule");
 
@@ -16,6 +17,10 @@ const server = express();
 
 server.use(bodyparser.urlencoded({ extended: false }));
 server.use(bodyparser.json());
+server.use((req, res, next) => {
+  db.read();
+  next();
+})
 
 server.get("/health-check", require("./api/index"));
 server.get("/health-check/critical", require("./api/critical"));

--- a/packages/health-check/src/index.js
+++ b/packages/health-check/src/index.js
@@ -20,7 +20,7 @@ server.use(bodyparser.json());
 server.use((req, res, next) => {
   db.read();
   next();
-})
+});
 
 server.get("/health-check", require("./api/index"));
 server.get("/health-check/critical", require("./api/critical"));

--- a/packages/health-check/src/schedule.js
+++ b/packages/health-check/src/schedule.js
@@ -10,7 +10,7 @@ const criticalJob = schedule.scheduleJob("*/5 * * * *", async () => {
     checks: await Promise.all(criticalChecks.map((check) => new Promise(check))),
   };
 
-  db.get("critical").push(entry).write();
+  db.read().get("critical").push(entry).write();
 });
 
 // execute the verbose health-check script once per hour
@@ -20,7 +20,7 @@ const verboseJob = schedule.scheduleJob("0 * * * *", async () => {
     checks: await Promise.all(verboseChecks.map((check) => new Promise(check))),
   };
 
-  db.get("verbose").push(entry).write();
+  db.read().get("verbose").push(entry).write();
 });
 
 // Launch Health check jobs


### PR DESCRIPTION
We need to make sure db is updated in memory each time we make a request because the underlying file could have been changed (due to other scripts, namely disable and enable cli scripts, modifying it). This is not ideal because most of the time it's redundant but it works for now. Better solution would be to have new private (internal) api endpoint (available only from localhost) that the cli would hit so the database would be modified only by one process.