### PR TITLE
Fix broken hns redirect

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -160,9 +160,9 @@ server {
 			local skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "sia://([^/?]+)(.*)")
 
 			-- in case the skylink did not match, assume that there is no sia:// prefix and try to match again
-			if skylink == nil then
-				skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "/?([^/?]+)(.*)")
-			end
+			-- if skylink == nil then
+			-- 	skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "/?([^/?]+)(.*)")
+			-- end
 
 			ngx.var.skylink = skylink
 			if request_uri_rest == "/" and skylink_rest ~= "" and skylink_rest ~= "/" then

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -147,9 +147,8 @@ server {
 			local skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "(sia://)([^/?]+)(.*)")
 
 			ngx.var.skylink = skylink
-			if request_uri_rest ~= "" and request_uri_rest ~= "/" then
-				ngx.var.rest = request_uri_rest
-			elseif skylink_rest ~= "" and skylink_rest ~= "/" then
+			ngx.var.rest = request_uri_rest
+			if skylink_rest ~= "" and skylink_rest ~= "/" and (request_uri_rest == "" or request_uri_rest == "/") then
 				ngx.var.rest = skylink_rest
 			end
 		}

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -170,6 +170,9 @@ server {
 			else
 				ngx.var.rest = request_uri_rest
 			end
+
+			ngx.header.proxy_skylink = skylink
+			ngx.header.proxy_rest = ngx.var.rest
 		}
 
 		# overwrite the Cache-Control header to only cache for 60s in case the domain gets updated

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -170,9 +170,6 @@ server {
 			else
 				ngx.var.rest = request_uri_rest
 			end
-
-			ngx.header.proxy_skylink = skylink
-			ngx.header.proxy_rest = ngx.var.rest
 		}
 
 		# overwrite the Cache-Control header to only cache for 60s in case the domain gets updated

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -162,10 +162,14 @@ server {
 
 		# in case siad returns location header, we need to replace the skylink with the domain name
 		header_filter_by_lua_block {
+			ngx.header.foo = ngx.header.location
+			ngx.header.fooo = ngx.var.skylink
+
 			if ngx.header.location then
 				local hns_domain_name = string.match(ngx.var.request_uri, "/hns/([^/?]+)")
 				local location = string.gsub(ngx.header.location, ngx.var.skylink, hns_domain_name)
 
+				ngx.header.foooo = hns_domain_name
 				ngx.header.location = location
 			end
 		}

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -147,10 +147,10 @@ server {
 			local skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "(sia://)([^/?]+)(.*)")
 
 			ngx.var.skylink = skylink
-			if request_uri_rest == "" or (request_uri_rest == "/" and skylink_rest ~= "") then
-				ngx.var.rest = skylink_rest
-			else
+			if request_uri_rest ~= "" or request_uri_rest ~= "/" then
 				ngx.var.rest = request_uri_rest
+			else if skylink_rest ~= "" or skylink_rest ~= "/" then
+				ngx.var.rest = skylink_rest
 			end
 		}
 

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -147,9 +147,9 @@ server {
 			local skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "(sia://)([^/?]+)(.*)")
 
 			ngx.var.skylink = skylink
-			if request_uri_rest ~= "" or request_uri_rest ~= "/" then
+			if request_uri_rest ~= "" and request_uri_rest ~= "/" then
 				ngx.var.rest = request_uri_rest
-			else if skylink_rest ~= "" or skylink_rest ~= "/" then
+			else if skylink_rest ~= "" and skylink_rest ~= "/" then
 				ngx.var.rest = skylink_rest
 			end
 		}

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -157,7 +157,7 @@ server {
 			local hnsres_json = json.decode(hnsres_res.body)
 
 			-- try to match the skylink with sia:// prefix
-			local skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "sia://([^/?]+)(.*)")
+			local skylink, skylink_rest = string.match(hnsres_json.skylink, "sia://([^/?]+)(.*)")
 
 			-- in case the skylink did not match, assume that there is no sia:// prefix and try to match again
 			-- if skylink == nil then

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -160,9 +160,9 @@ server {
 			local skylink, skylink_rest = string.match(hnsres_json.skylink, "sia://([^/?]+)(.*)")
 
 			-- in case the skylink did not match, assume that there is no sia:// prefix and try to match again
-			-- if skylink == nil then
-			-- 	skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "/?([^/?]+)(.*)")
-			-- end
+			if skylink == nil then
+				skylink, skylink_rest = string.match(hnsres_json.skylink, "/?([^/?]+)(.*)")
+			end
 
 			ngx.var.skylink = skylink
 			if request_uri_rest == "/" and skylink_rest ~= "" and skylink_rest ~= "/" then

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -164,7 +164,7 @@ server {
 		header_filter_by_lua_block {
 			if ngx.header.location then
 				local hns_domain_name = string.match(ngx.var.request_uri, "/hns/([^/?]+)")
-				local location_skylink, location_rest = string.match(hnsres_json.skylink, "([^/?]+)(.*)");
+				local location_skylink, location_rest = string.match(ngx.header.location, "([^/?]+)(.*)");
 				# local location = string.gsub(ngx.header.location, ngx.var.skylink, hns_domain_name)
 
 				ngx.header.location = hns_domain_name .. location_rest

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -147,9 +147,10 @@ server {
 			local skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "(sia://)([^/?]+)(.*)")
 
 			ngx.var.skylink = skylink
-			ngx.var.rest = request_uri_rest
-			if skylink_rest ~= "" and skylink_rest ~= "/" and (request_uri_rest == "" or request_uri_rest == "/") then
+			if request_uri_rest == "/" and skylink_rest ~= "" and skylink_rest ~= "/" then
 				ngx.var.rest = skylink_rest
+			else
+				ngx.var.rest = request_uri_rest
 			end
 		}
 

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -165,7 +165,6 @@ server {
 			if ngx.header.location then
 				local hns_domain_name = string.match(ngx.var.request_uri, "/hns/([^/?]+)")
 				local location_skylink, location_rest = string.match(ngx.header.location, "([^/?]+)(.*)");
-				# local location = string.gsub(ngx.header.location, ngx.var.skylink, hns_domain_name)
 
 				ngx.header.location = hns_domain_name .. location_rest
 			end

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -162,16 +162,12 @@ server {
 
 		# in case siad returns location header, we need to replace the skylink with the domain name
 		header_filter_by_lua_block {
-			ngx.header.foo = ngx.header.location
-			ngx.header.fooo = ngx.var.skylink
-
 			if ngx.header.location then
 				local hns_domain_name = string.match(ngx.var.request_uri, "/hns/([^/?]+)")
-				local location = string.gsub(ngx.header.location, ngx.var.skylink, hns_domain_name)
+				local location_skylink, location_rest = string.match(hnsres_json.skylink, "([^/?]+)(.*)");
+				# local location = string.gsub(ngx.header.location, ngx.var.skylink, hns_domain_name)
 
-				ngx.header.foooo = hns_domain_name
-				ngx.header.fooooo = location
-				ngx.header.location = location
+				ngx.header.location = hns_domain_name .. location_rest
 			end
 		}
 	}

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -149,7 +149,7 @@ server {
 			ngx.var.skylink = skylink
 			if request_uri_rest ~= "" and request_uri_rest ~= "/" then
 				ngx.var.rest = request_uri_rest
-			else if skylink_rest ~= "" and skylink_rest ~= "/" then
+			elseif skylink_rest ~= "" and skylink_rest ~= "/" then
 				ngx.var.rest = skylink_rest
 			end
 		}

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -130,21 +130,39 @@ server {
 	location /hns {
 		include /etc/nginx/conf.d/include/proxy-buffer;
 
+		# variable definititions - we need to define a variable to be able to access it in lua by ngx.var.something
 		set $skylink ''; # placeholder for the raw 46 bit skylink
 		set $rest ''; # placeholder for the rest of the url that gets appended to skylink (path and args)
 		
 		# resolve handshake domain by requesting to /hnsres endpoint and assign correct values to $skylink and $rest
 		access_by_lua_block {
 			local json = require('cjson')
+			
+			-- match the request_uri and extract the hns domain and anything that is passed in the uri after it
+			-- example: /hns/something/foo/bar?baz=1 matches:
+			-- > hns_domain_name: something
+			-- > request_uri_rest: /foo/bar/?baz=1
 			local hns_domain_name, request_uri_rest = string.match(ngx.var.request_uri, "/hns/([^/?]+)(.*)")
+
+			-- make a get request to /hnsres endpoint with the domain name from request_uri
 			local hnsres_res = ngx.location.capture("/hnsres/" .. hns_domain_name)
 
+			-- we want to fail with a generic 404 when /hnsres returns anything but 200 OK with a skylink
 			if hnsres_res.status ~= ngx.HTTP_OK then
 				ngx.exit(ngx.HTTP_NOT_FOUND)
 			end
 
+			-- since /hnsres endpoint response is a json, we need to decode it before we access it
+			-- example response: '{"skylink":"sia://XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg"}'
 			local hnsres_json = json.decode(hnsres_res.body)
-			local skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "(sia://)([^/?]+)(.*)")
+
+			-- try to match the skylink with sia:// prefix
+			local skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "sia://([^/?]+)(.*)")
+
+			-- in case the skylink did not match, assume that there is no sia:// prefix and try to match again
+			if skylink == nil then
+				skylink_prefix, skylink, skylink_rest = string.match(hnsres_json.skylink, "/?([^/?]+)(.*)")
+			end
 
 			ngx.var.skylink = skylink
 			if request_uri_rest == "/" and skylink_rest ~= "" and skylink_rest ~= "/" then
@@ -163,9 +181,14 @@ server {
 		# in case siad returns location header, we need to replace the skylink with the domain name
 		header_filter_by_lua_block {
 			if ngx.header.location then
+				-- match hns domain from the request_uri
 				local hns_domain_name = string.match(ngx.var.request_uri, "/hns/([^/?]+)")
+
+				-- match location redirect part after the skylink
 				local location_rest = string.match(ngx.header.location, "[^/?]+(.*)");
 
+				-- because siad will set the location header to ie. XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg/index.html
+				-- we need to replace the skylink with the domain_name so we are not redirected to skylink
 				ngx.header.location = hns_domain_name .. location_rest
 			end
 		}

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -164,7 +164,7 @@ server {
 		header_filter_by_lua_block {
 			if ngx.header.location then
 				local hns_domain_name = string.match(ngx.var.request_uri, "/hns/([^/?]+)")
-				local location_skylink, location_rest = string.match(ngx.header.location, "([^/?]+)(.*)");
+				local location_rest = string.match(ngx.header.location, "[^/?]+(.*)");
 
 				ngx.header.location = hns_domain_name .. location_rest
 			end

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -170,6 +170,7 @@ server {
 				local location = string.gsub(ngx.header.location, ngx.var.skylink, hns_domain_name)
 
 				ngx.header.foooo = hns_domain_name
+				ngx.header.fooooo = location
 				ngx.header.location = location
 			end
 		}


### PR DESCRIPTION
Only proxy to specific path if the request url ends with just a slash.

We cannot use `string.gsub` because it accepts a regular expression and we would have to escape the whole string, otherwise skylinks with dashes break the expression.

Test with:
https://siasky.dev/hns/uniswap-dex
https://siasky.dev/hns/uniswap-dex/
https://siasky.dev/hns/uniswap-dex?foo=bar
https://siasky.dev/hns/uniswap-dex/?foo=bar

https://siasky.dev/hns/convert-skylink
https://siasky.dev/hns/convert-skylink/
https://siasky.dev/hns/convert-skylink?foo=bar
https://siasky.dev/hns/convert-skylink/?foo=bar

https://siasky.dev/hns/big-buck-bunny
https://siasky.dev/hns/big-buck-bunny/
https://siasky.dev/hns/big-buck-bunny?foo=bar
https://siasky.dev/hns/big-buck-bunny/?foo=bar

https://siasky.dev/hns/wakio
https://siasky.dev/hns/wakio/
https://siasky.dev/hns/wakio?foo=bar
https://siasky.dev/hns/wakio/?foo=bar