### PR TITLE
drop legacy upload node support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,26 +31,6 @@ services:
     expose:
       - 9980
 
-  sia-upload:
-    build:
-      context: ./docker/sia
-      dockerfile: Dockerfile
-      args:
-        branch: v1.5.0
-    container_name: sia-upload
-    restart: unless-stopped
-    environment:
-      - SIA_MODULES=gctwr
-    env_file:
-      - .env-upload
-    volumes:
-      - ./docker/data/sia-upload:/sia-data
-    networks:
-      shared:
-        ipv4_address: 192.168.0.11
-    expose:
-      - 9980
-
   caddy:
     build:
       context: ./docker/caddy

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -108,19 +108,6 @@ server {
 		proxy_pass http://siad/skynet/stats;
 	}
 
-	# This endpoint is a backward compatilibilty workaround for reporting stats from legacy 
-	# upload siad node for portals that used double-siad setup. If your portal does not need
-	# to support additional siad node, you can remove it from this config.
-	location /statsdown {
-		include /etc/nginx/conf.d/include/cors;
-
-		proxy_cache skynet;
-		proxy_cache_valid any 10m; # cache stats for 10 minutes
-		proxy_set_header User-Agent: Sia-Agent;
-		proxy_read_timeout 5m; # extend the read timeout
-		proxy_pass http://sia-upload:9980/skynet/stats; # serve upload node stats temporarily
-	}
-
 	location /health-check {
 		include /etc/nginx/conf.d/include/cors;
 


### PR DESCRIPTION
- removes legacy sia-upload node from portal setup
- legacy portal need to run their upload node separately - recommended with docker https://hub.docker.com/r/nebulouslabs/sia