### PR TITLE
improve nginx config

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -234,35 +234,14 @@ server {
 	}
 
 	location @subdomain {
-		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/proxy-buffer;
-		include /etc/nginx/conf.d/include/proxy-cache-downloads;
 
-		limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
-		add_header Cache-Control "public, max-age=86400"; # allow consumer to cache response
-
-		proxy_read_timeout 600;
-		proxy_set_header User-Agent: Sia-Agent;
-		# proxy this call to siad /skynet/skylink/ endpoint (make sure the ip is correct)
-		proxy_pass http://siad/skynet/skylink/$subdomain/$request_uri;
+		proxy_pass http://127.0.0.1/$subdomain/$request_uri;
 	}
 
 	location ~ "^/file/([a-zA-Z0-9-_]{46}(/.*)?)$" {
-		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/proxy-buffer;
-		include /etc/nginx/conf.d/include/proxy-cache-downloads;
 
-		limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
-		add_header Cache-Control "public, max-age=86400"; # allow consumer to cache response
-
-		# we need to explicitly use set directive here because $1 will contain the skylink with
-		# decoded whitespaces and set will re-encode it for us before passing it to proxy_pass
-		set $skylink $1;
-
-		proxy_read_timeout 600;
-		proxy_set_header User-Agent: Sia-Agent;
-		# proxy this call to siad /skynet/skylink/ endpoint (make sure the ip is correct)
-		# this alias also adds attachment=true url param to force download the file
-		proxy_pass http://siad/skynet/skylink/$skylink?attachment=true&$args;
+		proxy_pass http://127.0.0.1/$uri?attachment=true&$args;
 	}
 }

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -215,7 +215,7 @@ server {
 		proxy_pass http://siad/skynet/skyfile/$dir1/$dir2/$dir3/$dir4$is_args$args;
 	}
 
-	location ~ "^/([a-zA-Z0-9-_]{46}(/.*)?)$" {
+	location ~ "^/(([a-zA-Z0-9-_]{46}|[a-z0-9]{55})(/.*)?)$" {
 		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/proxy-buffer;
 		include /etc/nginx/conf.d/include/proxy-cache-downloads;

--- a/docker/nginx/conf.d/include/proxy-cache-downloads
+++ b/docker/nginx/conf.d/include/proxy-cache-downloads
@@ -2,7 +2,7 @@ proxy_cache skynet;
 slice 1m;
 proxy_http_version 1.1; # upgrade if necessary because 1.0 does not support byte-range requests
 proxy_set_header Range $slice_range; # pass slice range to proxy
-proxy_cache_key $subdomain$uri$slice_range; # include both the $subdomain and $slice_range in the cache key
+proxy_cache_key $uri$arg_format$slice_range; # use just the uri path, format arg and slice range
 proxy_cache_min_uses 3; # cache responses after 3 requests of the same file
 proxy_cache_valid 200 206 24h; # cache 200 and 206 responses for 24 hours
 proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -39,7 +39,7 @@ http {
         '$status $body_bytes_sent "$http_referer" '
         '"$http_user_agent" $upstream_response_time '
         '$upstream_bytes_sent $upstream_bytes_received '
-        '"$upstream_http_content_type"';
+        '"$upstream_http_content_type" "$upstream_cache_status"';
 
     access_log  logs/access.log  main;
 


### PR DESCRIPTION
- proxy subdomain and /file locations to our general skylink location so we can drop unnecessary copy & paste logic and correctly count skylink usages from access.log
- include cache status in access log: "MISS", "HIT" or "BYPASS" (possibly "EXPIRED" but I've never seen it)
- improve cache key so whether you hit hns address or subdomain address or add weird args, it will correctly cache proxy response
    - remove `$subdomain` because proxy caching will be handled in different location
    - include `$arg_format` so we properly cache different response formats (don't include all `$args` because it's redundant and also it would mean that the location where we add `attachment=true` to args would get separate cached entries)