### PR TITLE
Support hns subdomains

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -6,7 +6,7 @@
 }
 
 (siasky.net) {
-    siasky.net, *.siasky.net {
+    siasky.net, *.siasky.net, *.hns.siasky.net {
         tls {
             dns route53
         }

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -22,7 +22,7 @@ server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
 
-	# parse subdomain (a base32 encoded Skylink) into custom variable
+	# understand the regex https://regex101.com/r/BGQvi6/2/
 	server_name "~^(((?<base32_subdomain>([a-z0-9]{55}))|(?<hns_domain>[^\.]+)\.hns)\.)?(?<domain>[^.]+)\.(?<tld>[^.]+)$";
 
 	# ddos protection: closing slow connections
@@ -35,18 +35,17 @@ server {
 	client_max_body_size 128k;
 
 	location / {
-		# The only safe thing to do inside an if in a location block is return
-		# or rewrite, since we need to proxy_pass we have to work our way around
-		# using a custom error code.
-		#
+		# This is only safe workaround to reroute based on some conditions
 		# See https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
 		recursive_error_pages on;
 
+		# redirect links with base32 encoded skylink in subdomain
 		error_page 418 = @base32_subdomain;
 		if ($base32_subdomain != "") {
 			return 418;
 		}
 
+		# redirect links with handshake domain on hns subdomain
 		error_page 419 = @hns_domain;
 		if ($hns_domain  != "") {
 			return 419;

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -23,8 +23,7 @@ server {
 	listen [::]:80 default_server;
 
 	# parse subdomain (a base32 encoded Skylink) into custom variable
-	server_name "~^([a-z0-9]{55})\..*$";
-	set $subdomain $1;
+	server_name "~^(((?<base32_subdomain>([a-z0-9]{55}))|(?<hns_domain>[^\.]+)\.hns)\.)?(?<domain>[^.]+)\.(?<tld>[^.]+)$";
 
 	# ddos protection: closing slow connections
 	client_body_timeout 5s;
@@ -41,10 +40,16 @@ server {
 		# using a custom error code.
 		#
 		# See https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
-		error_page 418 = @subdomain;
 		recursive_error_pages on;
-		if ($subdomain  != "") {
+
+		error_page 418 = @base32_subdomain;
+		if ($base32_subdomain != "") {
 			return 418;
+		}
+
+		error_page 419 = @hns_domain;
+		if ($hns_domain  != "") {
+			return 419;
 		}
 
 		include /etc/nginx/conf.d/include/cors;
@@ -233,10 +238,16 @@ server {
 		proxy_pass http://siad/skynet/skylink/$skylink$is_args$args;
 	}
 
-	location @subdomain {
+	location @base32_subdomain {
 		include /etc/nginx/conf.d/include/proxy-buffer;
 
-		proxy_pass http://127.0.0.1/$subdomain/$request_uri;
+		proxy_pass http://127.0.0.1/$base32_subdomain/$request_uri;
+	}
+
+	location @hns_domain {
+		include /etc/nginx/conf.d/include/proxy-buffer;
+
+		proxy_pass http://127.0.0.1/hns/$hns_domain/$request_uri;
 	}
 
 	location ~ "^/file/([a-zA-Z0-9-_]{46}(/.*)?)$" {


### PR DESCRIPTION
- rewrite server_name regex to include named capture groups
  - `hns_domain` - will contain a handshake domain if url formed like https://some-domain.hns.siasky.net
  - `base32_subdomain` - will contain base32 encoded skylink if url formed like https://base32here.siasky.net
- added new redirect location for hns subdomain