### PR TITLE
Update caddy

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -8,7 +8,9 @@
 (siasky.net) {
     siasky.net, *.siasky.net, *.hns.siasky.net {
         tls {
-            dns route53
+            dns route53 {
+                max_retries 100
+            }
             ttl 2m
         }
         reverse_proxy nginx:80

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -9,9 +9,8 @@
     siasky.net, *.siasky.net, *.hns.siasky.net {
         tls {
             dns route53 {
-                max_retries 100
+                max_retries 50
             }
-            ttl 2m
         }
         reverse_proxy nginx:80
     }

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -9,6 +9,7 @@
     siasky.net, *.siasky.net, *.hns.siasky.net {
         tls {
             dns route53
+            ttl 2m
         }
         reverse_proxy nginx:80
     }

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -1,7 +1,8 @@
-FROM caddy:2.1.1-builder AS caddy-builder
+FROM caddy:2.2.0-builder AS caddy-builder
 
-RUN caddy-builder github.com/caddy-dns/cloudflare github.com/caddy-dns/route53
+# available dns resolvers: https://github.com/caddy-dns
+RUN xcaddy build --with github.com/caddy-dns/route53
 
-FROM caddy:2.1.1
+FROM caddy:2.2.0
 
 COPY --from=caddy-builder /usr/bin/caddy /usr/bin/caddy


### PR DESCRIPTION
- update caddy to 2.2.0
- switch from using caddy-builder to xcaddy as per deprecation message
- drop cloudflare dns-01 provider from our base install and add a link to a repo with dns-01 providers
- set large enough `max_retries` because default is just 5 (also cannot set 0 as infinite because it will default to 5 anyway)