### PR TITLE
add portal_subdomain to nginx regex and fill documentation

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -22,8 +22,8 @@ server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
 
-	# understand the regex https://regex101.com/r/BGQvi6/2/
-	server_name "~^(((?<base32_subdomain>([a-z0-9]{55}))|(?<hns_domain>[^\.]+)\.hns)\.)?(?<domain>[^.]+)\.(?<tld>[^.]+)$";
+	# understand the regex https://regex101.com/r/BGQvi6/5
+	server_name "~^(((?<base32_skylink>([a-z0-9]{55}))|(?<hns_domain>[^\.]+)\.hns)\.)?((?<portal_domain>[^.]+)\.)?(?<domain>[^.]+)\.(?<tld>[^.]+)$";
 
 	# ddos protection: closing slow connections
 	client_body_timeout 5s;

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -40,15 +40,15 @@ server {
 		recursive_error_pages on;
 
 		# redirect links with base32 encoded skylink in subdomain
-		error_page 418 = @base32_subdomain;
+		error_page 460 = @base32_subdomain;
 		if ($base32_subdomain != "") {
-			return 418;
+			return 460;
 		}
 
 		# redirect links with handshake domain on hns subdomain
-		error_page 419 = @hns_domain;
+		error_page 461 = @hns_domain;
 		if ($hns_domain  != "") {
-			return 419;
+			return 461;
 		}
 
 		include /etc/nginx/conf.d/include/cors;

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -22,8 +22,8 @@ server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
 
-	# understand the regex https://regex101.com/r/BGQvi6/5
-	server_name "~^(((?<base32_skylink>([a-z0-9]{55}))|(?<hns_domain>[^\.]+)\.hns)\.)?((?<portal_domain>[^.]+)\.)?(?<domain>[^.]+)\.(?<tld>[^.]+)$";
+	# understand the regex https://regex101.com/r/BGQvi6/6
+	server_name "~^(((?<base32_subdomain>([a-z0-9]{55}))|(?<hns_domain>[^\.]+)\.hns)\.)?((?<portal_domain>[^.]+)\.)?(?<domain>[^.]+)\.(?<tld>[^.]+)$";
 
 	# ddos protection: closing slow connections
 	client_body_timeout 5s;

--- a/setup-scripts/README.md
+++ b/setup-scripts/README.md
@@ -121,8 +121,8 @@ In Nginx two things need to happen:
 #### Match the specific parts of the uri
 
 ```
-# understand the regex https://regex101.com/r/BGQvi6/5
-server_name "~^(((?<base32_skylink>([a-z0-9]{55}))|(?<hns_domain>[^\.]+)\.hns)\.)?((?<portal_domain>[^.]+)\.)?(?<domain>[^.]+)\.(?<tld>[^.]+)$";
+# understand the regex https://regex101.com/r/BGQvi6/6
+server_name "~^(((?<base32_subdomain>([a-z0-9]{55}))|(?<hns_domain>[^\.]+)\.hns)\.)?((?<portal_domain>[^.]+)\.)?(?<domain>[^.]+)\.(?<tld>[^.]+)$";
 ```
 
 #### Redirect the requests to the appropriate location

--- a/setup-scripts/README.md
+++ b/setup-scripts/README.md
@@ -131,7 +131,7 @@ First you need to redirect the requests based on the regex above matching either
 
 ```
 location / {
-  # This is only safe workaround to reroute based on some conditions
+  # This is the only safe workaround to reroute based on some conditions
   # See https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
   recursive_error_pages on;
 


### PR DESCRIPTION
- add `portal_domain` to nginx regex so we can successfully match skylink and hns subdomains on named portals like `https://us-east.siasky.net`
- improve documentation on subdomains

closes #421 