### PR TITLE
extend registry proxy timeout to 10 minutes

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -200,6 +200,7 @@ server {
 		include /etc/nginx/conf.d/include/sia-auth;
 
 		proxy_set_header User-Agent: Sia-Agent;
+		proxy_read_timeout 600; // siad should timeout with 404 after 5 minutes
 		proxy_pass http://siad/skynet/registry;
 	}
 


### PR DESCRIPTION
Siad will timeout with 404 after 5 minutes so we're extending the proxy timeout to 10 minutes (our standard siad proxy timeout) to let siad handle this.

closes https://github.com/NebulousLabs/skynet-webportal/issues/492