### PR TITLE
Add a MongoDB service.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,3 +160,18 @@ services:
     depends_on:
       - handshake
       - handshake-api
+
+  mongo:
+    image: mongo:4.4.1
+    command: --keyFile=/data/mgkey --replSet=skynet
+    container_name: mongo
+    restart: unless-stopped
+    logging: *default-logging
+    volumes:
+      - ./docker/data/mongo/db:/data/db
+      - ./docker/data/mongo/mgkey:/data/mgkey:rw
+    networks:
+      shared:
+        ipv4_address: 10.10.10.70
+    ports:
+      - "27017:27017"


### PR DESCRIPTION
## Overview

This PR adds a MongoDB service to the stack.

## Caveats
Before this service is usable (or even runnable) we need to do several manual steps on each node:
- open port 27017, preferably only to the other nodes in the cluster
- manually run an initialisation docker run with extra env variables that will initialise the admin user with a password
- manually add a `mgkey` file under `./docker/data/mongo` with the respective secret

During the initial run mentioned above, we need to make two extra steps _**within the container**_:
- change the ownership of `mgkey` to `mongodb:mongodb`
- change its permissions to 400

After these steps are done we can open a mongo shell on the master node and run `rs.add()` in order to add the new node to the cluster.

## Notes

### Cluster initialisation

Initialisation docker run command:
```
docker run \
	--rm \
	--name mg \
	-p 27017:27017 \
	-e MONGO_INITDB_ROOT_USERNAME=<admin username> \
	-e MONGO_INITDB_ROOT_PASSWORD=<admin password> \
	-v /home/user/skynet-webportal/docker/data/mongo/db:/data/db \
	-v /home/user/skynet-webportal/docker/data/mongo/mgkey:/data/mgkey \
	mongo --replSet=skynet
```

Regular docker run command:
```
docker run \
        -d \
	--rm \
	--name mg \
	-p 27017:27017 \
	-v /home/user/skynet-webportal/docker/data/mongo/db:/data/db \
	-v /home/user/skynet-webportal/docker/data/mongo/mgkey:/data/mgkey \
	mongo --keyFile=/data/mgkey --replSet=skynet
```

Cluster initialisation `mongo` command:
```
rs.initiate(
  {
    _id : "skynet",
    members: [
      { _id : 0, host : "helsinki.siasky.net:27017" },
      { _id : 1, host : "us-va-1.siasky.net:27017" },
    ]
  }
)
```
Adding a new node (after the node is set up on its own):
```
rs.add({_id : 3, host : "germany.siasky.net"})
```

### Failover

Failover is automatic. What I did to test that is:
* start with the above two-node cluster
* add a third node
* kill the master node
* insert a record on one of the other two nodes
* read it from the other

## To Do
After we have this running, it would be nice to harden the security a bit and to make it easier to add new configuration options in the future.

### Security
We are currently using the so-called "keyfile access control" which is not great for production use. We need to switch to using x.509 certificates. This is explained here: https://docs.mongodb.com/manual/core/security-x.509/ 

### Configuration
Instead of running the `mongo` command with the `--keyFile=/data/mgkey --replSet=skynet` parameters we can run it with `--config /etc/mongo/mongod.conf` and moount a proper config file at that location.

An initial config file can look like this:
```
security:
  keyFile: /data/db/mgkey
replication:
  replSetName: skynet
```