### PR TITLE
Support skydb in hns

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -151,12 +151,39 @@ server {
 			-- example response: '{"skylink":"sia://XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg"}'
 			local hnsres_json = json.decode(hnsres_res.body)
 
-			-- try to match the skylink with sia:// prefix
-			local skylink, skylink_rest = string.match(hnsres_json.skylink, "sia://([^/?]+)(.*)")
+			if hnsres_json.skylink then
+				-- try to match the skylink with sia:// prefix
+				local skylink, skylink_rest = string.match(hnsres_json.skylink, "sia://([^/?]+)(.*)")
 
-			-- in case the skylink did not match, assume that there is no sia:// prefix and try to match again
-			if skylink == nil then
-				skylink, skylink_rest = string.match(hnsres_json.skylink, "/?([^/?]+)(.*)")
+				-- in case the skylink did not match, assume that there is no sia:// prefix and try to match again
+				if skylink == nil then
+					skylink, skylink_rest = string.match(hnsres_json.skylink, "/?([^/?]+)(.*)")
+				end
+			end
+
+			if hnsres_json.registry then
+				local publickey = hnsres_json.registry.publickey
+				local datakey = hnsres_json.registry.datakey
+
+				-- make a get request to /skynet/registry endpoint with the credentials from text record
+				local registry_res = ngx.location.capture("/skynet/registry?publickey=" .. publickey .. "&datakey=" .. datakey)
+
+				ngx.header.content_type = 'text/plain'
+				ngx.print(registry_res.body)
+
+				-- we want to fail with a generic 404 when /skynet/registry returns anything but 200 OK
+				if registry_res.status ~= ngx.HTTP_OK then
+					ngx.exit(ngx.HTTP_NOT_FOUND)
+				end
+
+				-- since /skynet/registry endpoint response is a json, we need to decode it before we access it
+				local registry_json = json.decode(registry_res.body)
+				-- response will contain hex encoded, we need to decode it
+				local data = (registry_json.data:gsub('..', function (cc)
+					return string.char(tonumber(cc, 16))
+				end))
+
+				skylink = data
 			end
 
 			ngx.var.skylink = skylink

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -180,10 +180,6 @@ server {
 					return string.char(tonumber(cc, 16))
 				end))
 
-				ngx.header.content_type = 'text/plain'
-				ngx.print(data)
-				ngx.exit(ngx.HTTP_OK)
-
 				skylink = data
 			end
 

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -175,7 +175,7 @@ server {
 
 				-- since /skynet/registry endpoint response is a json, we need to decode it before we access it
 				local registry_json = json.decode(registry_res.body)
-				-- response will contain hex encoded, we need to decode it
+				-- response will contain a hex encoded skylink, we need to decode it
 				local data = (registry_json.data:gsub('..', function (cc)
 					return string.char(tonumber(cc, 16))
 				end))

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -159,9 +159,7 @@ server {
 				if skylink == nil then
 					skylink, skylink_rest = string.match(hnsres_json.skylink, "/?([^/?]+)(.*)")
 				end
-			end
-
-			if hnsres_json.registry then
+			elseif hnsres_json.registry then
 				local publickey = hnsres_json.registry.publickey
 				local datakey = hnsres_json.registry.datakey
 
@@ -181,6 +179,11 @@ server {
 				end))
 
 				skylink = data
+			end
+
+			-- fail with a generic 404 if skylink has not been extracted from a valid /hnsres response for some reason
+			if not skylink then
+				ngx.exit(ngx.HTTP_NOT_FOUND)
 			end
 
 			ngx.var.skylink = skylink

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -168,9 +168,6 @@ server {
 				-- make a get request to /skynet/registry endpoint with the credentials from text record
 				local registry_res = ngx.location.capture("/skynet/registry?publickey=" .. publickey .. "&datakey=" .. datakey)
 
-				ngx.header.content_type = 'text/plain'
-				ngx.print(registry_res.body)
-
 				-- we want to fail with a generic 404 when /skynet/registry returns anything but 200 OK
 				if registry_res.status ~= ngx.HTTP_OK then
 					ngx.exit(ngx.HTTP_NOT_FOUND)
@@ -182,6 +179,10 @@ server {
 				local data = (registry_json.data:gsub('..', function (cc)
 					return string.char(tonumber(cc, 16))
 				end))
+
+				ngx.header.content_type = 'text/plain'
+				ngx.print(data)
+				ngx.exit(ngx.HTTP_OK)
 
 				skylink = data
 			end

--- a/packages/handshake-api/src/index.js
+++ b/packages/handshake-api/src/index.js
@@ -6,7 +6,7 @@ const { NodeClient } = require("hs-client");
 const host = process.env.HOSTNAME || "0.0.0.0";
 const port = Number(process.env.PORT) || 3100;
 
-const hsdNetworkType = process.env.HSD_NETWORK || "regtest";
+const hsdNetworkType = process.env.HSD_NETWORK || "main";
 const hsdHost = process.env.HSD_HOST || "localhost";
 const hsdPort = Number(process.env.HSD_PORT) || 12037;
 const hsdApiKey = process.env.HSD_API_KEY || "foo";
@@ -18,10 +18,11 @@ const clientOptions = {
   apiKey: hsdApiKey,
 };
 const client = new NodeClient(clientOptions);
-const cache = new NodeCache({ stdTTL: 300 }); // cache for 5 minutes
+const cache = new NodeCache({ stdTTL: 1 }); // cache for 5 minutes
 
 // Match both `sia://HASH` and `HASH` links.
 const startsWithSkylinkRegExp = /^(sia:\/\/)?[a-zA-Z0-9_-]{46}/;
+const registryEntryRegExp = /^skydb:\/\/(?<publickey>[a-zA-Z0-9%]+)\/(?<datakey>[a-zA-Z0-9%]+)$/;
 
 const getDomainRecords = async (name) => {
   if (cache.has(name)) return cache.get(name);
@@ -36,18 +37,36 @@ const getDomainRecords = async (name) => {
   return records;
 };
 
-const findSkylinkRecord = (records) => {
+const findSkynetCompatibleRecord = (records) => {
   // Find the last one, so people can update their domains in a non-destructive
   // way by simply adding a new link. This will also allow keeping links to
   // older versions for backwards compatibility.
   return records
     ?.slice()
     .reverse()
-    .find(({ txt }) => txt?.some((entry) => isValidSkylink(entry)));
+    .find(({ txt }) => txt?.some((entry) => isValidSkylink(entry) || isValidRegistryEntry(entry)));
 };
 
-const getSkylinkFromRecord = (record) => {
-  return record?.txt?.find((entry) => isValidSkylink(entry));
+const createResponseFromCompatibleRecord = (record) => {
+  const skylink = record?.txt?.find((entry) => isValidSkylink(entry));
+
+  if (skylink) return { skylink };
+
+  const entry = record?.txt?.find((entry) => isValidRegistryEntry(entry));
+
+  if (entry) {
+    const match = entry.match(registryEntryRegExp);
+
+    if (match)
+      return {
+        registry: {
+          publickey: decodeURIComponent(match.groups.publickey),
+          datakey: decodeURIComponent(match.groups.datakey),
+        },
+      };
+  }
+
+  throw new Error(`No skylink in record: ${JSON.stringify(record)}`);
 };
 
 const resolveDomainHandler = async (req, res) => {
@@ -56,11 +75,10 @@ const resolveDomainHandler = async (req, res) => {
     const records = await getDomainRecords(domain);
     if (!records) return res.status(404).send(`No records found for ${domain}`);
 
-    const record = findSkylinkRecord(records);
-    if (!record) throw new Error(`No skylink found in dns records of ${domain}`);
+    const record = findSkynetCompatibleRecord(records);
+    if (!record) throw new Error(`No skynet compatible records found in dns records of ${domain}`);
 
-    const skylink = getSkylinkFromRecord(record);
-    return res.json({ skylink });
+    return res.json(createResponseFromCompatibleRecord(record));
   } catch (error) {
     res.status(500).send(`Handshake error: ${error.message}`);
   }
@@ -72,6 +90,10 @@ function isValidSkylink(link) {
     return false;
   }
   return Boolean(link.match(startsWithSkylinkRegExp));
+}
+
+function isValidRegistryEntry(value) {
+  return Boolean(value && value.match(registryEntryRegExp));
 }
 
 const server = express();

--- a/packages/handshake-api/src/index.js
+++ b/packages/handshake-api/src/index.js
@@ -85,13 +85,11 @@ const resolveDomainHandler = async (req, res) => {
 };
 
 // Checks if the given string is a valid Sia link.
-function isValidSkylink(link) {
-  if (!link || link.length === 0) {
-    return false;
-  }
-  return Boolean(link.match(startsWithSkylinkRegExp));
+function isValidSkylink(value) {
+  return Boolean(value && value.match(startsWithSkylinkRegExp));
 }
 
+// Checks if given string is a valid skynet registry entry
 function isValidRegistryEntry(value) {
   return Boolean(value && value.match(registryEntryRegExp));
 }

--- a/packages/handshake-api/src/index.js
+++ b/packages/handshake-api/src/index.js
@@ -18,7 +18,7 @@ const clientOptions = {
   apiKey: hsdApiKey,
 };
 const client = new NodeClient(clientOptions);
-const cache = new NodeCache({ stdTTL: 1 }); // cache for 5 minutes
+const cache = new NodeCache({ stdTTL: 300 }); // cache for 5 minutes
 
 // Match both `sia://HASH` and `HASH` links.
 const startsWithSkylinkRegExp = /^(sia:\/\/)?[a-zA-Z0-9_-]{46}/;


### PR DESCRIPTION
- extend /hnsres endpoint to return either skylink or registry entry based on what has been stored in the dns entry (support for `skydb://<publickey>/<datakey>` format - **should be uri-encoded**)
- support parsing registry entry in /hns endpoint

### extending `/hnsres` payload
`/hnsres` depending on the domain entry will now return:
- skylink entry, example for domain configuration 
```
sia://GACSvPi8yHr7s0IALienivoMLnwxy787Ptg5vseNxD46BA
```
```json
{
  "skylink": "GACSvPi8yHr7s0IALienivoMLnwxy787Ptg5vseNxD46BA"
}
```
- registry entry, example for domain configuration:
```
skydb://ed25519%3Ad611373052bb124f23c3376a181e140390d9545666dae333acee2402dfc95f4a/79c05b4b67764ad99a7976a7d2fb1cfce4f196ea217ef0356af042cb5492bd5d
```
```json
{
  "registry": {
    "publickey": "ed25519:d611373052bb124f23c3376a181e140390d9545666dae333acee2402dfc95f4a",
    "datakey": "79c05b4b67764ad99a7976a7d2fb1cfce4f196ea217ef0356af042cb5492bd5d"
  }
}
```