### PR TITLE
Update Nginx log format

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -40,7 +40,7 @@ http {
         '"$http_user_agent" $upstream_response_time '
         '$upstream_bytes_sent $upstream_bytes_received '
         '"$upstream_http_content_type" "$upstream_cache_status" '
-        '"$portal_domain"';
+        '"$portal_domain" "$upstream_http_skynet_skylink"';
 
     access_log  logs/access.log  main;
 


### PR DESCRIPTION
I would like to update the nginx log format to include the `Skynet-Skylink` header that is returned by `siad`. This way we know what Skylink has been uploaded by looking at the access logs, which is useful for debugging purposes.

I have yet to test this on a server. I wanted to try it out on `siasky.xyz` but there I was getting a 401 on upload.
Once I've managed to test it out - I'll remove the draft status.

Tested on skynet.xyz:
```
141.134.206.3 - - [25/Nov/2020:12:18:04 +0000] "GET /favicon-32x32.png?v=98e70ab9b5b382484de5d5587fa2d1a8 HTTP/1.1" 200 1977 "https://siasky.xyz/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.67 Safari/537.36" - - - "-" "-" "" "-"
141.134.206.3 - - [25/Nov/2020:12:18:10 +0000] "POST /skynet/skyfile HTTP/1.1" 200 154 "https://siasky.xyz/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.67 Safari/537.36" 1.124 1021 342 "application/json; charset=utf-8" "-" "" "AACkvm8DfEaVuDS7jXAuhb6DCg-39Qbzerpd6G0_CeNa1Q"
```