### PR TITLE
Ratelimit

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -3,7 +3,7 @@ proxy_cache_path /data/nginx/cache levels=1:2 keys_zone=skynet:10m max_size=10g 
 # ratelimit specified IPs
 geo $limit {
 	default 0;
-	include /etc/nginx/conf.d/include/ratelimited;
+	include /etc/nginx/conf.d/include/ratelimited/*;
 }
 map $limit $limit_key {
 	0 "";

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -10,8 +10,8 @@ map $limit $limit_key {
 	1 $binary_remote_addr;
 }
 
-limit_req_zone $binary_remote_addr zone=upload_req:10m rate=10r/s;
-limit_req_zone $limit_key zone=upload_req_rl:10m rate=10r/m;
+limit_req_zone $binary_remote_addr zone=uploads_by_ip:10m rate=10r/s;
+limit_req_zone $limit_key zone=uploads_by_ip_throttled:10m rate=10r/m;
 
 limit_conn_zone $binary_remote_addr zone=upload_conn:10m;
 limit_conn_zone $limit_key zone=upload_conn_rl:10m;
@@ -244,8 +244,8 @@ server {
 		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/sia-auth;
 
-		limit_req zone=upload_req burst=100 nodelay;
-		limit_req zone=upload_req_rl;
+		limit_req zone=uploads_by_ip burst=100 nodelay;
+		limit_req zone=uploads_by_ip_throttled;
 
 		limit_conn upload_conn 10;
 		limit_conn upload_conn_rl 1;

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -1,6 +1,21 @@
 proxy_cache_path /data/nginx/cache levels=1:2 keys_zone=skynet:10m max_size=10g use_temp_path=off;
-limit_req_zone $binary_remote_addr zone=stats_by_ip:10m rate=10r/m;
-limit_conn_zone $binary_remote_addr zone=uploads_by_ip:10m;
+
+# ratelimit specified IPs
+geo $limit {
+	default 0;
+	include /etc/nginx/conf.d/include/ratelimited;
+}
+map $limit $limit_key {
+	0 "";
+	1 $binary_remote_addr;
+}
+
+limit_req_zone $binary_remote_addr zone=upload_req:10m rate=10r/s;
+limit_req_zone $limit_key zone=upload_req_rl:10m rate=10r/m;
+
+limit_conn_zone $binary_remote_addr zone=upload_conn:10m;
+limit_conn_zone $limit_key zone=upload_conn_rl:10m;
+
 limit_conn_zone $binary_remote_addr zone=downloads_by_ip:10m;
 limit_req_status 429;
 limit_conn_status 429;
@@ -229,7 +244,12 @@ server {
 		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/sia-auth;
 
-		limit_conn uploads_by_ip 10; # ddos protection: max 10 uploads at a time
+		limit_req zone=upload_req burst=100 nodelay;
+		limit_req zone=upload_req_rl;
+
+		limit_conn upload_conn 10;
+		limit_conn upload_conn_rl 1;
+
 		client_max_body_size 1000M; # make sure to limit the size of upload to a sane value
 		proxy_read_timeout 600;
 		proxy_request_buffering off; # stream uploaded files through the proxy as it comes in

--- a/docker/nginx/conf.d/include/ratelimited
+++ b/docker/nginx/conf.d/include/ratelimited
@@ -1,0 +1,6 @@
+# Add a list of IPs here that should be severaly rate limited on upload.
+# Note that it is possible to add IP ranges as well as the full IP address.
+#
+# Examples:
+# 192.168.0.0/24 1;
+# 79.85.222.247 1;

--- a/docker/nginx/conf.d/include/ratelimited
+++ b/docker/nginx/conf.d/include/ratelimited
@@ -1,4 +1,4 @@
-# Add a list of IPs here that should be severaly rate limited on upload.
+# Add a list of IPs here that should be severely rate limited on upload.
 # Note that it is possible to add IP ranges as well as the full IP address.
 #
 # Examples:

--- a/docker/nginx/conf.d/include/ratelimited/example
+++ b/docker/nginx/conf.d/include/ratelimited/example
@@ -1,4 +1,6 @@
 # Add a list of IPs here that should be severely rate limited on upload.
+# Every file in this directory will be included.
+#
 # Note that it is possible to add IP ranges as well as the full IP address.
 #
 # Examples:


### PR DESCRIPTION
This PR adds a mechanism to rate-limit upload requests by keeping a "blocklist" that specifies heavy uploader IP addresses.
It works by defining a `$limit_key` depending on whether the current IP is part of that list, if so, the key will be specified and the rate-limited zone, which is obvioulsy the most restrictive, will get applied.

I've chosen to apply rate limits on upload by default, but I've made it so that the default values are very forgiving. I limit both the requests per second and the number of connections severely for users that are on the block list.
E.g. 1 connection per IP and only 10 requests per minute.

By default it's 10 connections per IP, and 10 requests per second, with an allowed burst of 100 requests, which I think is fine.
Unfortunately we could not use `rate_limit`, as that only allows to limit the rate of response transmission.

This was not tested yet! So do not merge it yet.