### PR TITLE
add option to pass a list of skylinks for blocklist

### DIFF
--- a/scripts/blocklist-skylink.sh
+++ b/scripts/blocklist-skylink.sh
@@ -14,13 +14,15 @@ skylinks=()
 if test -f "$1"; then
     OLDIFS=$IFS
     IFS=','
+    line_number=1
     while read line
     do
         if [[ $line =~ ([a-zA-Z0-9_-]{46}) ]]; then
             skylinks+=("$BASH_REMATCH")
         else
-            echo "Incorrect skylink: $line" && exit 1
+            echo "Incorrect skylink at line ${line_number}: $line" && exit 1
         fi
+        let line_number+=1
     done < $1;
     IFS=$OLDIFS
 else

--- a/scripts/blocklist-skylink.sh
+++ b/scripts/blocklist-skylink.sh
@@ -44,7 +44,7 @@ do
     ######################################################
     # purge nginx cache after all the skylinks are blocked
     ######################################################
-    ssh -q -t user@${server} 'rm -rf /home/user/skynet_webportal/docker/data/nginx/cache'
+    ssh -q -t user@${server} 'docker exec nginx sh -c "rm -rf /data/nginx/cache/*"'
     echo ".... 🗑️ Pruned nginx cache on ${server}"
 done
 

--- a/scripts/blocklist-skylink.sh
+++ b/scripts/blocklist-skylink.sh
@@ -3,7 +3,7 @@
 set -e # exit on first error
 
 if [ -z "$1" ]; then
-    echo "Please provide either a skylink or file with skylinks separated by blank lines" && exit 1
+    echo "Please provide either a skylink or file with skylinks separated by new lines" && exit 1
 fi
 
 #########################################################

--- a/scripts/blocklist-skylink.sh
+++ b/scripts/blocklist-skylink.sh
@@ -3,14 +3,49 @@
 set -e # exit on first error
 
 if [ -z "$1" ]; then
-    echo "Please provide a skylink to blocklist" && exit 1
+    echo "Please provide either a skylink or file with skylinks separated by blank lines" && exit 1
 fi
 
+#########################################################
+# read either a file containing skylinks separated by new 
+# lines or a single skylink and put them in an array
+#########################################################
+skylinks=()
+if test -f "$1"; then
+    OLDIFS=$IFS
+    IFS=','
+    while read line
+    do
+        if [[ $line =~ ([a-zA-Z0-9_-]{46}) ]]; then
+            skylinks+=("$BASH_REMATCH")
+        else
+            echo "Incorrect skylink: $line" && exit 1
+        fi
+    done < $1;
+    IFS=$OLDIFS
+else
+    skylinks=("$1") # just single skylink passed as input argument
+fi
+
+####################################################
+# iterate through all servers and block the skylinks
+####################################################
 for server in "germany.siasky.net" "helsinki.siasky.net" "us-west.siasky.net" "us-va-1.siasky.net" "us-pa-1.siasky.net" "us-pa-2.siasky.net" "siasky.xyz";
 do
-    echo "⌁ Blocking skylink on ${server}"
-    ssh -q -t user@${server} 'docker exec sia siac skynet blocklist add '$1''
-    ssh -q -t user@${server} 'rm -rf /home/user/skynet_webportal/docker/data/nginx/cache' # prune nginx cache
+    #############################################################
+    # iterate throught all skylinks and add each one to blocklist
+    #############################################################
+    for skylink in "${skylinks[@]}";
+    do
+        echo ".. ⌁ Blocking skylink ${skylink} on ${server}"
+        ssh -q -t user@${server} 'docker exec sia siac skynet blocklist add '$skylink''
+    done
+
+    ######################################################
+    # purge nginx cache after all the skylinks are blocked
+    ######################################################
+    ssh -q -t user@${server} 'rm -rf /home/user/skynet_webportal/docker/data/nginx/cache'
+    echo ".... 🗑️ Pruned nginx cache on ${server}"
 done
 
-echo "✓ All portals succesfully blocklisted $1"
+echo "✓ All done !"


### PR DESCRIPTION
To improve skylink blocklist update process, we can now pass a file path as an argument to scripts/blocklist-skylink.sh

ex. `scripts/blocklist-skylink.sh all_skylinks_to_block.txt`

Script will ssh into each server, block all skylinks and then prune the nginx cache once.