### PR TITLE
Revert wildcard include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,6 @@ packages/webapp/cypress/videos
 
 # Docker data
 docker/data
-docker/nginx/conf.d/include/ratelimited/*
-!docker/nginx/conf.d/include/ratelimited/example
 
 # Docker override
 docker-compose.override.yml

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -3,7 +3,7 @@ proxy_cache_path /data/nginx/cache levels=1:2 keys_zone=skynet:10m max_size=10g 
 # ratelimit specified IPs
 geo $limit {
 	default 0;
-	include /etc/nginx/conf.d/include/ratelimited/*;
+	include /etc/nginx/conf.d/include/ratelimited;
 }
 map $limit $limit_key {
 	0 "";

--- a/docker/nginx/conf.d/include/ratelimited
+++ b/docker/nginx/conf.d/include/ratelimited
@@ -1,6 +1,4 @@
 # Add a list of IPs here that should be severely rate limited on upload.
-# Every file in this directory will be included.
-#
 # Note that it is possible to add IP ranges as well as the full IP address.
 #
 # Examples:


### PR DESCRIPTION
Turns out the wildcard include does not work. Most probably due to a bug in nginx actually, because the include does work outside of the `map`, and it should also work inside of the `map` I believe. This is not important, we should revert to how it was and not spend too much time on it. It works/worked.