### PR TITLE
add server override includes and redirect legacy endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,10 @@ docker/data
 # Docker override
 docker-compose.override.yml
 
+# Nginx custom server overrides
+docker/nginx/conf.d/server-override/*
+!docker/nginx/conf.d/server-override/example
+
 # Cache files
 __pycache__
 /.idea/

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -50,6 +50,8 @@ server {
 	client_max_body_size 128k;
 
 	# legacy endpoint rewrite
+	rewrite /portals /skynet/portals permanent;
+	rewrite /stats /skynet/stats permanent;
 	rewrite /skynet/blacklist /skynet/blocklist permanent;
 
 	location / {
@@ -87,15 +89,6 @@ server {
 		proxy_pass http://siad/skynet/blocklist;
 	}
 
-	location /portals {
-		include /etc/nginx/conf.d/include/cors;
-
-		proxy_cache skynet;
-		proxy_cache_valid any 1m; # cache portals for 1 minute
-		proxy_set_header User-Agent: Sia-Agent;
-		proxy_pass http://siad/skynet/portals;
-	}
-
 	location /skynet/portals {
 		include /etc/nginx/conf.d/include/cors;
 
@@ -103,16 +96,6 @@ server {
 		proxy_cache_valid any 1m; # cache portals for 1 minute
 		proxy_set_header User-Agent: Sia-Agent;
 		proxy_pass http://siad/skynet/portals;
-	}
-
-	location /stats {
-		include /etc/nginx/conf.d/include/cors;
-
-		proxy_cache skynet;
-		proxy_cache_valid any 10m; # cache stats for 10 minutes
-		proxy_set_header User-Agent: Sia-Agent;
-		proxy_read_timeout 5m; # extend the read timeout
-		proxy_pass http://siad/skynet/stats;
 	}
 
 	location /skynet/stats {
@@ -308,4 +291,7 @@ server {
 
 		proxy_pass http://127.0.0.1/$uri?attachment=true&$args;
 	}
+
+	# include custom locations, specific to the server
+	include /etc/nginx/conf.d/locations/*;
 }

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -293,5 +293,5 @@ server {
 	}
 
 	# include custom locations, specific to the server
-	include /etc/nginx/conf.d/locations/*;
+	include /etc/nginx/conf.d/server-override/*;
 }

--- a/docker/nginx/conf.d/server-override/example
+++ b/docker/nginx/conf.d/server-override/example
@@ -1,0 +1,7 @@
+# Every file from within this directory will be included in the server block
+# of the nginx configuration, at the very end. See client.conf.
+#
+# Example:
+# location /blog {
+#     root /var/www/blog;
+# }


### PR DESCRIPTION
- added wildcard include at the end of server block in nginx client.conf to allow custom includes that are not commited to repo
- permanently redirected /stats and /portals to /skynet/stats and /skynet/portals respectively as a part of config cleanup (already did that for blocklist)