### PR TITLE
fix downloading skylink

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -289,9 +289,9 @@ server {
 	location ~ "^/file/([a-zA-Z0-9-_]{46}(/.*)?)$" {
 		include /etc/nginx/conf.d/include/proxy-buffer;
 
-		rewrite /file/(.*) $1 break;
+		rewrite /file/(.*) $1 break; # drop the /file/ prefix from uri
 
-		proxy_pass http://127.0.0.1/$1?attachment=true&$args;
+		proxy_pass http://127.0.0.1/$uri?attachment=true&$args;
 	}
 
 	# include custom locations, specific to the server

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -289,7 +289,9 @@ server {
 	location ~ "^/file/([a-zA-Z0-9-_]{46}(/.*)?)$" {
 		include /etc/nginx/conf.d/include/proxy-buffer;
 
-		proxy_pass http://127.0.0.1/$uri?attachment=true&$args;
+		rewrite /file/(.*) $1 break;
+
+		proxy_pass http://127.0.0.1/$1?attachment=true&$args;
 	}
 
 	# include custom locations, specific to the server

--- a/docker/nginx/conf.d/include/proxy-cache-downloads
+++ b/docker/nginx/conf.d/include/proxy-cache-downloads
@@ -2,7 +2,7 @@ proxy_cache skynet;
 slice 1m;
 proxy_http_version 1.1; # upgrade if necessary because 1.0 does not support byte-range requests
 proxy_set_header Range $slice_range; # pass slice range to proxy
-proxy_cache_key $uri$arg_format$slice_range; # use just the uri path, format arg and slice range
+proxy_cache_key $uri$arg_format$arg_attachment$slice_range; # use just the uri path, format and attachment args and slice range
 proxy_cache_min_uses 3; # cache responses after 3 requests of the same file
 proxy_cache_valid 200 206 24h; # cache 200 and 206 responses for 24 hours
 proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option


### PR DESCRIPTION
- `/file` endpoint did not work at all, `$uri` container a whole uri with `/file` prefix so it actually did an infinite loop
- added `$arg_attachment` to nginx cache key because otherwise nginx would return cached version regardless whether attachment has been set to true or not