### PR TITLE
Add wallet address to funds check message when funds are low

### DIFF
--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -162,6 +162,14 @@ class siad:
         return json.loads(resp.decode("utf-8"))
 
     @staticmethod
+    def get(endpoint):
+        if not setup_done:
+            setup()
+
+        resp = urllib.request.urlopen(api_endpoint + endpoint).read()
+        return siad.load_json(resp)
+
+    @staticmethod
     def get_wallet():
         if not setup_done:
             setup()

--- a/setup-scripts/funds-checker.py
+++ b/setup-scripts/funds-checker.py
@@ -64,7 +64,9 @@ async def check_funds():
 
     # Send an alert if there is less than 1 allowance worth of money left.
     if balance < allowance_funds:
-        message = "__Wallet balance running low!__ {}".format(balance_msg)
+        wallet_address_res = siad.get("/wallet/address")
+        wallet_msg = "Address: {}".format(wallet_address_res["address"])
+        message = "__Wallet balance running low!__ {} {}".format(balance_msg, wallet_msg)
         return await send_msg(client, message, force_notify=True)
 
     # Alert devs when only a fraction of the allowance is remaining.


### PR DESCRIPTION
Adds a wallet address to the "low balance" message.

Example:

> germany.siasky.net: Wallet balance running low! Balance: 215588 SC, Allowance Funds: 240000 SC Address: eee8cee82a5f998a712429f3ca41ebd1111cb6fbf7fce7cb645b98b8ab6aad4613c63cc96ea0 /cc @skynet-prod

https://discord.com/channels/542938080349519882/684543533155352599/781915395602513961