### PR TITLE
limit registry access in nginx

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -13,10 +13,14 @@ map $limit $limit_key {
 limit_req_zone $binary_remote_addr zone=uploads_by_ip:10m rate=10r/s;
 limit_req_zone $limit_key zone=uploads_by_ip_throttled:10m rate=10r/m;
 
+limit_req_zone $binary_remote_addr zone=registry_access_by_ip:10m rate=60r/m;
+limit_req_zone $limit_key zone=registry_access_by_ip_throttled:10m rate=20r/m;
+
 limit_conn_zone $binary_remote_addr zone=upload_conn:10m;
 limit_conn_zone $limit_key zone=upload_conn_rl:10m;
 
 limit_conn_zone $binary_remote_addr zone=downloads_by_ip:10m;
+
 limit_req_status 429;
 limit_conn_status 429;
 
@@ -217,6 +221,9 @@ server {
 	location /skynet/registry {
 		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/sia-auth;
+
+		limit_req zone=registry_access_by_ip burst=600 nodelay;
+		limit_req zone=registry_access_by_ip_throttled burst=200 nodelay;
 
 		proxy_set_header User-Agent: Sia-Agent;
 		proxy_read_timeout 600; # siad should timeout with 404 after 5 minutes


### PR DESCRIPTION
Limits:
- 60 requests from one ip per minute with a burst up to 600 without delay
- 20 requests from one throttled ip per minute with a burst up to 200 without delay