### PR TITLE
Fix /portals and /stats rewrites

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -54,9 +54,9 @@ server {
 	client_max_body_size 128k;
 
 	# legacy endpoint rewrite
-	rewrite /portals /skynet/portals permanent;
-	rewrite /stats /skynet/stats permanent;
-	rewrite /skynet/blacklist /skynet/blocklist permanent;
+	rewrite ^/portals /skynet/portals permanent;
+	rewrite ^/stats /skynet/stats permanent;
+	rewrite ^/skynet/blacklist /skynet/blocklist permanent;
 
 	location / {
 		# This is only safe workaround to reroute based on some conditions


### PR DESCRIPTION
Fixed /portals and /stats rewrites - since the first argument of rewrite is regex, it matched the url that was rewritten and caused infinite redirect. Fixed it with regex `^` prefix meaning that the url has to start with that phrase to redirect accordingly. Also added the same for blocklist redirect just to be consistent.