### PR TITLE
allow to include previous skynet stats

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - ./docker/nginx/conf.d:/etc/nginx/conf.d:ro
       - ./docker/data/nginx/cache:/data/nginx/cache
       - ./docker/data/nginx/logs:/usr/local/openresty/nginx/logs
+      - ./docker/data/nginx/skynet:/data/nginx/skynet:ro
       - ./docker/data/sia/apipassword:/data/sia/apipassword:ro
       - webapp:/var/www/webportal:ro
     networks:

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -105,6 +105,28 @@ server {
 	location /skynet/stats {
 		include /etc/nginx/conf.d/include/cors;
 
+		set $response_body ''; # we need a variable for full response body (not chuncked)
+
+		# modify the response to add numfiles and totalsize to account for node rotation
+		# example prevstats.lua: 'return { numfiles = 12345, totalsize = 123456789 }'
+		body_filter_by_lua_block {
+			local file_exists = io.open("/data/nginx/skynet/prevstats.lua")
+			if file_exists then
+				file_exists.close()
+				ngx.var.response_body = ngx.var.response_body .. ngx.arg[1]
+			    if ngx.arg[2] then
+					local json = require('cjson')
+					local prevstats = require('/data/nginx/skynet/prevstats')
+					local stats = json.decode(ngx.var.response_body)
+					stats.uploadstats.numfiles = stats.uploadstats.numfiles + prevstats.numfiles
+					stats.uploadstats.totalsize = stats.uploadstats.totalsize + prevstats.totalsize
+					ngx.arg[1] = json.encode(stats)
+				else
+					ngx.arg[1] = nil -- do not send any data in this chunk
+				end
+			end
+		}
+
 		proxy_cache skynet;
 		proxy_cache_valid any 10m; # cache stats for 10 minutes
 		proxy_set_header User-Agent: Sia-Agent;

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -113,8 +113,12 @@ server {
 			local file_exists = io.open("/data/nginx/skynet/prevstats.lua")
 			if file_exists then
 				file_exists.close()
+				
+				-- because response data is chunked, we need to concat ngx.arg[1] until
+				-- last chunk is received (when ngx.arg[2] is set to true)
 				ngx.var.response_body = ngx.var.response_body .. ngx.arg[1]
-			    if ngx.arg[2] then
+				
+				if ngx.arg[2] then
 					local json = require('cjson')
 					local prevstats = require('/data/nginx/skynet/prevstats')
 					local stats = json.decode(ngx.var.response_body)
@@ -122,7 +126,8 @@ server {
 					stats.uploadstats.totalsize = stats.uploadstats.totalsize + prevstats.totalsize
 					ngx.arg[1] = json.encode(stats)
 				else
-					ngx.arg[1] = nil -- do not send any data in this chunk
+					-- do not send any data in this chunk (wait for last chunk)
+					ngx.arg[1] = nil
 				end
 			end
 		}


### PR DESCRIPTION
In a case where the server had to be reinitialised with a new siad node, you might want to add the old siad node storage stats to the current node /skynet/stats. This is handy when we move the siad node to maintenance after it reaches certain amount of files (these nodes do not expose any api) but we would want to keep the server stats nevertheless. In future https://siasky.net/skynet/stats should probably expose combined stats from all servers.

To add previous stats, create docker/data/nginx/skynet/prevstats.lua file (example below) and reload nginx config.
```lua
return { numfiles = 12345, totalsize = 123456789 }
```