### PR TITLE
Remove problematic quoting.

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -24,8 +24,8 @@ limit_conn_zone $binary_remote_addr zone=downloads_by_ip:10m;
 limit_req_status 429;
 limit_conn_status 429;
 
-# since we are proxying request to nginx from caddy, access logs will contain caddy's ip address 
-# as the request address so we need to use real_ip_header module to use ip address from 
+# since we are proxying request to nginx from caddy, access logs will contain caddy's ip address
+# as the request address so we need to use real_ip_header module to use ip address from
 # X-Forwarded-For header as a real ip address of the request
 set_real_ip_from  10.0.0.0/8;
 set_real_ip_from  127.0.0.1/32;
@@ -42,7 +42,7 @@ server {
 	listen [::]:80 default_server;
 
 	# understand the regex https://regex101.com/r/BGQvi6/6
-	server_name "~^(((?<base32_subdomain>([a-z0-9]{55}))|(?<hns_domain>[^\.]+)\.hns)\.)?((?<portal_domain>[^.]+)\.)?(?<domain>[^.]+)\.(?<tld>[^.]+)$";
+	server_name ~^(((?<base32_subdomain>([a-z0-9]{55}))|(?<hns_domain>[^\.]+)\.hns)\.)?((?<portal_domain>[^.]+)\.)?(?<domain>[^.]+)\.(?<tld>[^.]+)$;
 
 	# ddos protection: closing slow connections
 	client_body_timeout 5s;
@@ -113,11 +113,11 @@ server {
 			local file_exists = io.open("/data/nginx/skynet/prevstats.lua")
 			if file_exists then
 				file_exists.close()
-				
+
 				-- because response data is chunked, we need to concat ngx.arg[1] until
 				-- last chunk is received (when ngx.arg[2] is set to true)
 				ngx.var.response_body = ngx.var.response_body .. ngx.arg[1]
-				
+
 				if ngx.arg[2] then
 					local json = require('cjson')
 					local prevstats = require('/data/nginx/skynet/prevstats')
@@ -153,11 +153,11 @@ server {
 		# variable definititions - we need to define a variable to be able to access it in lua by ngx.var.something
 		set $skylink ''; # placeholder for the raw 46 bit skylink
 		set $rest ''; # placeholder for the rest of the url that gets appended to skylink (path and args)
-		
+
 		# resolve handshake domain by requesting to /hnsres endpoint and assign correct values to $skylink and $rest
 		access_by_lua_block {
 			local json = require('cjson')
-			
+
 			-- match the request_uri and extract the hns domain and anything that is passed in the uri after it
 			-- example: /hns/something/foo/bar?baz=1 matches:
 			-- > hns_domain_name: something
@@ -221,7 +221,7 @@ server {
 
 		# overwrite the Cache-Control header to only cache for 60s in case the domain gets updated
 		more_set_headers 'Cache-Control: public, max-age=60';
-		
+
 		# we proxy to another nginx location rather than directly to siad because we don't want to deal with caching here
 		proxy_pass http://127.0.0.1/$skylink$rest;
 
@@ -292,7 +292,7 @@ server {
 		proxy_pass http://siad/skynet/skyfile/$dir1/$dir2/$dir3/$dir4$is_args$args;
 	}
 
-	location ~ "^/(([a-zA-Z0-9-_]{46}|[a-z0-9]{55})(/.*)?)$" {
+	location ~ ^/(([a-zA-Z0-9-_]{46}|[a-z0-9]{55})(/.*)?)$ {
 		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/proxy-buffer;
 		include /etc/nginx/conf.d/include/proxy-cache-downloads;
@@ -339,7 +339,7 @@ server {
 		content_by_lua_file /etc/nginx/conf.d/scripts/purge-multi.lua;
 	}
 
-	location ~ "^/file/([a-zA-Z0-9-_]{46}(/.*)?)$" {
+	location ~ ^/file/([a-zA-Z0-9-_]{46}(/.*)?)$ {
 		include /etc/nginx/conf.d/include/proxy-buffer;
 
 		rewrite /file/(.*) $1 break; # drop the /file/ prefix from uri


### PR DESCRIPTION
According to all documentation I found, `server_name` and `location` directives using regexes shouldn't have those regexes in quotes. Having them in quotes basically results in using them as a hardcoded string with the string appearing in the logs.

I am creating this PR as draft because the regexes don't seem to work right now. I'm not sure why but I'm also not willing to mess with those without understanding them well enough. @kwypchlo, let's talk about it and see how we can fix it.