### PR TITLE
Extend `nginx` log format

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -40,7 +40,7 @@ http {
         '"$http_user_agent" $upstream_response_time '
         '$upstream_bytes_sent $upstream_bytes_received '
         '"$upstream_http_content_type" "$upstream_cache_status" '
-        '"$portal_domain" "$upstream_http_skynet_skylink"';
+        '"$portal_domain" "$upstream_http_skynet_skylink" "$hns_domain"';
 
     access_log  logs/access.log  main;
 


### PR DESCRIPTION
This extends the log format to include the `hns` subdomain. 