### PR TITLE
upgrade openresty image to ubuntu 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,9 @@ services:
       - nginx
 
   nginx:
-    image: openresty/openresty:1.15.8.3-2-xenial
+    build:
+      context: ./docker/nginx
+      dockerfile: Dockerfile
     container_name: nginx
     restart: unless-stopped
     logging: *default-logging

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,7 @@
+FROM openresty/openresty:1.19.3.1-2-bionic
+
+# RUN apt-get update -qq && apt-get install cron logrotate -qq
+# RUN luarocks install luasocket
+
+# CMD ["sh", "-c", "service cron start;", "/usr/local/openresty/bin/openresty -g daemon off;"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]


### PR DESCRIPTION
- use ubuntu 18 openresty image instead of ubuntu 16 image that has not been maintained for quite a while now
- use Dockerfile to enable future extensions to openresty - https://github.com/NebulousLabs/skynet-webportal/pull/554 will require luasocket and we will need to fix logs rotation at some point too