### PR TITLE
reduce directory tree nesting size

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -275,21 +275,20 @@ server {
 		proxy_set_header Expect $http_expect;
 		proxy_set_header User-Agent: Sia-Agent;
 
-		# Extract 3 sets of 2 characters from $request_id and assign to $dir1, $dir2, $dir3
-		# respectfully. The rest of the $request_id is going to be assigned to $dir4.
+		# Extract 2 sets of 2 characters from $request_id and assign to $dir1, $dir2
+		# respectfully. The rest of the $request_id is going to be assigned to $dir3.
 		# We use those variables to automatically generate a unique path for the uploaded file.
 		# This ensures that not all uploaded files end up in the same directory, which is something
 		# that causes performance issues in the renter.
-		# Example path result: /af/24/9b/c5ec894920ccc45634dc9a8065
-		if ($request_id ~* "(\w{2})(\w{2})(\w{2})(\w+)") {
+		# Example path result: /af/24/9bc5ec894920ccc45634dc9a8065
+		if ($request_id ~* "(\w{2})(\w{2})(\w+)") {
 			set $dir1 $1;
 			set $dir2 $2;
 			set $dir3 $3;
-			set $dir4 $4;
 		}
 
 		# proxy this call to siad endpoint (make sure the ip is correct)
-		proxy_pass http://siad/skynet/skyfile/$dir1/$dir2/$dir3/$dir4$is_args$args;
+		proxy_pass http://siad/skynet/skyfile/$dir1/$dir2/$dir3$is_args$args;
 	}
 
 	location ~ "^/(([a-zA-Z0-9-_]{46}|[a-z0-9]{55})(/.*)?)$" {


### PR DESCRIPTION
reducing directory tree size to improve health loop efficiency, already tested on siasky.net maintenance nodes