### PR TITLE
add new nginx metrics to measure performance

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -41,9 +41,8 @@ http {
         '$upstream_bytes_sent $upstream_bytes_received '
         '"$upstream_http_content_type" "$upstream_cache_status" '
         '"$portal_domain" "$upstream_http_skynet_skylink" '
-        'request_time=$request_time '
-        'upstream_connect_time=$upstream_connect_time '
-        'upstream_header_time=$upstream_header_time';
+        '$upstream_connect_time $upstream_header_time '
+        '$request_time "$hns_domain"';
 
     access_log  logs/access.log  main;
 

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -40,7 +40,10 @@ http {
         '"$http_user_agent" $upstream_response_time '
         '$upstream_bytes_sent $upstream_bytes_received '
         '"$upstream_http_content_type" "$upstream_cache_status" '
-        '"$portal_domain" "$upstream_http_skynet_skylink"';
+        '"$portal_domain" "$upstream_http_skynet_skylink" '
+        'request_time=$request_time '
+        'upstream_connect_time=$upstream_connect_time '
+        'upstream_header_time=$upstream_header_time';
 
     access_log  logs/access.log  main;
 


### PR DESCRIPTION
https://www.nginx.com/blog/using-nginx-logging-for-application-performance-monitoring

> $request_time – Full request time, starting when NGINX reads the first byte from the client and ending when NGINX sends the last byte of the response body
> $upstream_connect_time – Time spent establishing a connection with an upstream server
> $upstream_header_time – Time between establishing a connection to an upstream server and receiving the first byte of the response header
> $upstream_response_time – Time between establishing a connection to an upstream server and receiving the last byte of the response body

We already had `$upstream_response_time` but we could use other ones too, especially `$upstream_header_time` to measure time to first byte from siad on requests. I used the format in nginx that was suggested in the article because if we just keep adding new numbers, we might lose track of what did they mean in the end (hence labels in the log format) - this is a proposal, up for a discussion because we did not use it until now.

edit: added $hns_domain

closes #578