### PR TITLE
fix hns links redirects

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -212,7 +212,7 @@ server {
 			end
 
 			ngx.var.skylink = skylink
-			if request_uri_rest == "/" and skylink_rest ~= "" and skylink_rest ~= "/" then
+			if request_uri_rest == "/" and skylink_rest ~= nil and skylink_rest ~= "" and skylink_rest ~= "/" then
 				ngx.var.rest = skylink_rest
 			else
 				ngx.var.rest = request_uri_rest

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -176,6 +176,9 @@ server {
 			-- example response: '{"skylink":"sia://XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg"}'
 			local hnsres_json = json.decode(hnsres_res.body)
 
+			-- define local variable containing rest of the skylink if provided
+			local skylink_rest
+
 			if hnsres_json.skylink then
 				-- try to match the skylink with sia:// prefix
 				skylink, skylink_rest = string.match(hnsres_json.skylink, "sia://([^/?]+)(.*)")


### PR DESCRIPTION
probably due to upgrade in nginx we introduced an issue where handshake domains accessed with https://siasky.net/hns/domain_name/ would not register the trailing slash and would redirect to https://siasky.net/hns/domain_name/domain_name/ and error out

the weird thing is that it sometimes work and sometimes it doesn't - probably due to the variable being set somewhere globally, that's why we need to explicitly declare it as local

broken commit https://github.com/NebulousLabs/skynet-webportal/commit/c946014e7c1d97f93667e3c87363204348ccca64