### PR TITLE
Add registry entries resolution caching

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -192,7 +192,7 @@ server {
 				local datakey = hnsres_json.registry.datakey
 
 				-- make a get request to /skynet/registry endpoint with the credentials from text record
-				local registry_res = ngx.location.capture("/skynet/registry?publickey=" .. publickey .. "&datakey=" .. datakey)
+				local registry_res = ngx.location.capture("/skynet/registry/cached?publickey=" .. publickey .. "&datakey=" .. datakey)
 
 				-- we want to fail with a generic 404 when /skynet/registry returns anything but 200 OK
 				if registry_res.status ~= ngx.HTTP_OK then
@@ -250,10 +250,27 @@ server {
 		proxy_pass http://handshake-api:3100;
 	}
 
+	# internal registry endpoint that caches calls for a certain period of time
+	# it is not suitable for every registry call but some requests might be cached
+	# and we are using it currently for caching registry resolutions from /hns calls
+	location /skynet/registry/cached {
+		internal; # internal endpoint only
+		access_log off; # do not log traffic 
+
+		proxy_cache skynet;
+		proxy_http_version 1.1; # upgrade if necessary
+		proxy_cache_key publickey=$arg_publickey&datakey=$arg_datakey; # cache based on publickey and datakey
+		proxy_cache_valid 200 30s; # cache only 200 responses and only for 30 seconds
+		proxy_cache_lock on; # queue cache requests for the same resource until it is fully cached
+		proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option
+		add_header X-Proxy-Cache $upstream_cache_status; # add response header to indicate cache hits and misses
+
+		http://127.0.0.1/skynet/registry$is_args$args;
+	}
+
 	location /skynet/registry {
 		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/sia-auth;
-		include /etc/nginx/conf.d/include/proxy-cache-registry;
 
 		limit_req zone=registry_access_by_ip burst=600 nodelay;
 		limit_req zone=registry_access_by_ip_throttled burst=200 nodelay;

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -253,6 +253,7 @@ server {
 	location /skynet/registry {
 		include /etc/nginx/conf.d/include/cors;
 		include /etc/nginx/conf.d/include/sia-auth;
+		include /etc/nginx/conf.d/include/proxy-cache-registry;
 
 		limit_req zone=registry_access_by_ip burst=600 nodelay;
 		limit_req zone=registry_access_by_ip_throttled burst=200 nodelay;

--- a/docker/nginx/conf.d/include/proxy-cache-registry
+++ b/docker/nginx/conf.d/include/proxy-cache-registry
@@ -1,7 +1,0 @@
-proxy_cache skynet;
-proxy_http_version 1.1; # upgrade if necessary
-proxy_cache_key publickey=$arg_publickey&datakey=$arg_datakey; # cache based on publickey and datakey
-proxy_cache_valid 200 30s; # cache only 200 responses and only for 30 seconds
-proxy_cache_lock on; # queue cache requests for the same resource until it is fully cached
-proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option
-add_header X-Proxy-Cache $upstream_cache_status; # add response header to indicate cache hits and misses

--- a/docker/nginx/conf.d/include/proxy-cache-registry
+++ b/docker/nginx/conf.d/include/proxy-cache-registry
@@ -1,0 +1,7 @@
+proxy_cache skynet;
+proxy_http_version 1.1; # upgrade if necessary
+proxy_cache_key publickey=$arg_publickey&datakey=$arg_datakey; # cache based on publickey and datakey
+proxy_cache_valid 200 30s; # cache only 200 responses and only for 30 seconds
+proxy_cache_lock on; # queue cache requests for the same resource until it is fully cached
+proxy_cache_bypass $cookie_nocache $arg_nocache; # add cache bypass option
+add_header X-Proxy-Cache $upstream_cache_status; # add response header to indicate cache hits and misses


### PR DESCRIPTION
cache registry calls that come from /hns endpoint - these registry entries are used to redirect a handshake domain to a certain skylink and are not updated too often and it is ok to expect some delay between the registry update and siasky to pick it up (up to 30s) just as regular dns records are cached for anywhere between 60s to 300s