### PR TITLE
Include Skynet-Portal-Api header

### DIFF
--- a/docker/nginx/conf.d/include/cors
+++ b/docker/nginx/conf.d/include/cors
@@ -11,4 +11,4 @@ if ($request_method = 'OPTIONS') {
 more_set_headers 'Access-Control-Allow-Origin: *';
 more_set_headers 'Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE';
 more_set_headers 'Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-more_set_headers 'Access-Control-Expose-Headers: Content-Length,Content-Range,Skynet-File-Metadata,Skynet-Skylink';
+more_set_headers 'Access-Control-Expose-Headers: Content-Length,Content-Range,Skynet-File-Metadata,Skynet-Skylink,Skynet-Portal-Api';

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -25,6 +25,7 @@ worker_processes  1;
 
 #pid        logs/nginx.pid;
 
+env SKYNET_PORTAL_API; # declare env variable to use it in config
 
 events {
     worker_connections  1024;
@@ -61,6 +62,9 @@ http {
     keepalive_timeout  65;
 
     #gzip  on;
+
+    # include skynet-portal-api header on every request
+    header_filter_by_lua 'ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")';
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/setup-scripts/setup-docker-services.sh
+++ b/setup-scripts/setup-docker-services.sh
@@ -22,6 +22,7 @@ docker-compose --version # sanity check
 
 # Create dummy .env file for docker-compose usage with variables
 # * DOMAIN_NAME - the domain name your server is using ie. example.com
+# * SKYNET_PORTAL_API - absolute url to the portal api ie. https://example.com
 # * EMAIL_ADDRESS - this is the administrator contact email you need to supply for communication regarding SSL certification
 # * HSD_API_KEY - this is auto generated secure key for your handshake service integration
 # * CLOUDFLARE_AUTH_TOKEN` - (optional) if using cloudflare as dns loadbalancer (need to change it in Caddyfile too)
@@ -32,7 +33,7 @@ docker-compose --version # sanity check
 # * DISCORD_BOT_TOKEN - required by the discord bot
 if ! [ -f /home/user/skynet-webportal/.env ]; then
     HSD_API_KEY=$(openssl rand -base64 32) # generate safe random key for handshake
-    printf "DOMAIN_NAME=example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nPORTAL_NAME=\nDISCORD_BOT_TOKEN=\n" > /home/user/skynet-webportal/.env
+    printf "DOMAIN_NAME=example.com\nSKYNET_PORTAL_API=https://example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nPORTAL_NAME=\nDISCORD_BOT_TOKEN=\n" > /home/user/skynet-webportal/.env
 fi
 
 # Start docker container with nginx and client


### PR DESCRIPTION
Header `skynet-portal-api` will be included on every portal response whether it's a GET, POST or HEAD.
This allows anyone to basically to write
```js
const skynetPortalApi = (await fetch("", { method: "HEAD" })).headers.get("Skynet-Portal-Api")
```
and through cheap, small and fast HEAD request acquire Skynet-Portal-Api value when calling from a portal hosted web app since the url we query `""` which is an empty relative url, will just use the current address. It is possible to instead of `""` use `"/"` but it doesn't really matter much.

In terms of naming, it's called exactly `Skynet-Portal-Api` in the nginx because the headers that start with `Skynet-` are the ones that siad returns and they are all Pascal-Kebab-Case (first letter capitalised, words separated by dash). In most cases, letter casing doesn't matter because clients are either case insensitive or transform the header into lower-kebab-case anyway - that js example with `fetch` above, you could use `"Skynet-Portal-Api"` and `"skynet-portal-api"` and both would be correctly returned.

**migration note:** portal operators will be required to add a new environment variable into the `.env` file called `SKYNET_PORTAL_API` which is the absolute url to the portal api (for us it is https://siasky.net), otherwise the header will not be included in the responses.

**verification:** run the example snippet on:
- https://siasky.dev
- https://siasky.dev/hns/marstorage/
- https://marstorage.hns.siasky.dev

closes #423