### PR TITLE
Airtable blocklist

### DIFF
--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -45,7 +45,7 @@ async def block_skylinks_from_airtable():
 
     print("Clearing nginx cache related to blocked skylinks")
     find_all_cache_files = '/usr/bin/find /data/nginx/cache/ -type f'
-    grep_pattern = '^KEY: .*(' + '|'.join(skylinks) + ')'
+    grep_pattern = '\'^KEY: .*(' + '|'.join(skylinks) + ')\''
     filter_matching_files = '/usr/bin/xargs --no-run-if-empty -n1000 /bin/grep -El ' + grep_pattern
     print('docker exec -it nginx bash -c "' + find_all_cache_files + ' | ' + filter_matching_files + '"')
     os.popen('docker exec -it nginx bash -c "' + find_all_cache_files + ' | ' + filter_matching_files + '"')

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import traceback, os, asyncio, requests, json, discord
+import traceback, os, re, asyncio, requests, json, discord
 from bot_utils import setup, send_msg
 
 bot_token = setup()

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -97,10 +97,8 @@ async def on_ready():
 
 client.run(bot_token)
 
-# asyncio.run(on_ready())
-
 # --- BASH EQUIVALENT
-# skylinks=$(curl "https://api.airtable.com/v0/${AIRTABLE_BASE}/Table%201?fields%5B%5D=Link" -H "Authorization: Bearer ${AIRTABLE_KEY}" | python3 -c "import sys, json; print('[\"' + '\",\"'.join([entry['fields']['Link'] for entry in json.load(sys.stdin)['records']]) + '\"]')")
+# skylinks=$(curl "https://api.airtable.com/v0/${AIRTABLE_BASE}/${AIRTABLE_TABLE}?fields%5B%5D=${AIRTABLE_FIELD}" -H "Authorization: Bearer ${AIRTABLE_KEY}" | python3 -c "import sys, json; print('[\"' + '\",\"'.join([entry['fields']['Link'] for entry in json.load(sys.stdin)['records']]) + '\"]')")
 # apipassword=$(docker exec sia cat /sia-data/apipassword)
 # ipaddress=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' sia)
 # curl -A "Sia-Agent" --user "":"${apipassword}" --data "{\"add\" : ${skylinks}}" "${ipaddress}:9980/skynet/blocklist"

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -15,7 +15,7 @@ async def block_skylinks_from_airtable():
     print("Pulling blocked skylinks from airtable via api integration")
     headers = { "Authorization": "Bearer " + AIRTABLE_API_KEY }
     skylinks = []
-    offset = ''
+    offset = None
     while len(skylinks) == 0 or offset:
         query = '&'.join(['fields%5B%5D=' + AIRTABLE_FIELD, ('offset=' + offset) if offset else ''])
         airtable = requests.get(
@@ -32,9 +32,9 @@ async def block_skylinks_from_airtable():
         if len(skylinks) == 0:
             return print("Airtable returned 0 skylinks - make sure your configuration is correct")
         
-        print(airtable_data.offset)
-        offset = airtable_data.offset
-        print(airtable_data.offset)
+        print(offset)
+        offset = airtable_data.get('offset')
+        print(offset)
     
     print("Airtable returned " + str(len(skylinks)) + " skylinks to block")
     

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -49,8 +49,8 @@ async def block_skylinks_from_airtable():
     skylinks = [skylink for skylink in skylinks if re.search("^[a-zA-Z0-9_-]{46}$", skylink)]
 
     if len(skylinks_returned) != len(skylinks):
-        message = (skylinks_returned - len(skylinks)) + " of the skylinks returned from Airtable are not valid"
         invalid_skylinks = [str(skylink) for skylink in list(set(skylinks_returned) - set(skylinks))]
+        message = str(len(invalid_skylinks)) + " of the skylinks returned from Airtable are not valid"
         print(message) or await send_msg(client, message, file=("\n".join(invalid_skylinks)))
 
     apipassword = exec("docker exec sia cat /sia-data/apipassword")

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -19,7 +19,7 @@ async def block_skylinks_from_airtable():
 
     if airtable.status_code != 200:
         message = "Airtable blocklist integration responded with code " + str(airtable.status_code) + ": " + (airtable.text or "empty response")
-        return print(message) or await send_msg(client, message, force_notify=False)
+        return print(message) or await send_msg(client, message, force_notify=True)
     
     skylinks = [entry['fields'][AIRTABLE_FIELD] for entry in airtable.json()['records']]
     print("Airtable returned " + str(len(skylinks)) + " skylinks to block")
@@ -37,7 +37,7 @@ async def block_skylinks_from_airtable():
         return print("Skylinks successfully added to siad blocklist")
     else:
         message = "Siad blocklist endpoint responded with code " + str(response.status_code) + ": " + (response.text or "empty response")
-        return await print(message) or send_msg(client, message, force_notify=False)
+        return await print(message) or send_msg(client, message, force_notify=True)
 
 async def exit_after(delay):
     await asyncio.sleep(delay)
@@ -48,7 +48,7 @@ async def on_ready():
     try:
         await block_skylinks_from_airtable()
     except:  # catch all exceptions
-        await send_msg(client, "```\n{}\n```".format(traceback.format_exc()), force_notify=False)
+        await send_msg(client, "```\n{}\n```".format(traceback.format_exc()), force_notify=True)
     asyncio.create_task(exit_after(3))
     
 client.run(bot_token)

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -38,7 +38,7 @@ async def block_skylinks_from_airtable():
     response = requests.post('http://' + ipaddress + ':9980/skynet/blocklist', auth = auth, headers = headers, data = data)
     
     if response.status_code == 204:
-        print("Skylinks successfully added to siad blocklist")
+        print("Siad blocklist succesfully updated with provided skylink")
     else:
         message = "Siad blocklist endpoint responded with code " + str(response.status_code) + ": " + (response.text or "empty response")
         return print(message) or await send_msg(client, message, force_notify=True)

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -51,7 +51,7 @@ async def block_skylinks_from_airtable():
         return print("No nginx cached files matching blocked skylinks were found")
 
     os.popen('docker exec -it nginx bash -c "' + cached_files_command + ' | xargs rm"')
-    message = "Purged " + str(cached_files_count) + " blocklisted files from nginx cache")
+    message = 'Purged ' + str(cached_files_count) + ' blocklisted files from nginx cache'
     return print(message) or await send_msg(client, message)
 
 async def exit_after(delay):

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -3,12 +3,12 @@
 import traceback, os, asyncio, requests, json, discord
 from bot_utils import setup, send_msg
 
+bot_token = setup()
+client = discord.Client()
+
 AIRTABLE_TABLE = "app89plJvA9EqTJEc"
 AIRTABLE_FIELD = "Link"
 AIRTABLE_API_KEY = os.getenv('AIRTABLE_API_KEY')
-
-bot_token = setup()
-client = discord.Client()
 
 async def block_skylinks_from_airtable():
     print("Pulling blocked skylinks from airtable via api integration")

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -43,12 +43,10 @@ async def block_skylinks_from_airtable():
         message = "Siad blocklist endpoint responded with code " + str(response.status_code) + ": " + (response.text or "empty response")
         return await print(message) or send_msg(client, message, force_notify=True)
 
-    print("Clearing nginx cache related to blocked skylinks")
-    find_all_cache_files = '/usr/bin/find /data/nginx/cache/ -type f'
-    grep_pattern = '\'^KEY: .*(' + '|'.join(skylinks) + ')\''
-    filter_matching_files = '/usr/bin/xargs --no-run-if-empty -n1000 /bin/grep -El ' + grep_pattern
-    print('docker exec -it nginx bash -c "' + find_all_cache_files + ' | ' + filter_matching_files + '"')
-    os.popen('docker exec -it nginx bash -c "' + find_all_cache_files + ' | ' + filter_matching_files + '"')
+    print("Purging nginx cache containing blocked skylinks")
+    purge_command = '/usr/bin/find /data/nginx/cache/ -type f | /usr/bin/xargs --no-run-if-empty -n1000 /bin/grep -El \'^KEY: .*(' + '|'.join(skylinks) + ')\''
+    cached_files = os.popen('docker exec -it nginx bash -c "' + purge_command + '"').read().strip()
+    print(cached_files)
 
 async def exit_after(delay):
     await asyncio.sleep(delay)

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -45,6 +45,8 @@ async def on_ready():
         await send_msg(client, "```\n{}\n```".format(traceback.format_exc()), force_notify=True)
     asyncio.create_task(exit_after(3))
     
+client.run(bot_token)
+
 # asyncio.run(on_ready())
 
 # --- BASH EQUIVALENT

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -5,6 +5,7 @@ from bot_utils import setup, send_msg
 
 AIRTABLE_TABLE = "app89plJvA9EqTJEc"
 AIRTABLE_FIELD = "Link"
+AIRTABLE_API_KEY = os.getenv('AIRTABLE_API_KEY')
 
 bot_token = setup()
 client = discord.Client()
@@ -31,7 +32,7 @@ async def block_skylinks_from_airtable():
         print("Skylinks successfully added to siad blocklist")
     else:
         message = "Siad blocklist endpoint responded with code " + str(response.status_code) + ": " + (response.text or "empty response")
-        await send_msg(client, message, force_notify=True)
+        await send_msg(client, message, force_notify=False)
 
 async def exit_after(delay):
     await asyncio.sleep(delay)
@@ -42,7 +43,7 @@ async def on_ready():
     try:
         await block_skylinks_from_airtable()
     except:  # catch all exceptions
-        await send_msg(client, "```\n{}\n```".format(traceback.format_exc()), force_notify=True)
+        await send_msg(client, "```\n{}\n```".format(traceback.format_exc()), force_notify=False)
     asyncio.create_task(exit_after(3))
     
 client.run(bot_token)

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -18,7 +18,7 @@ async def block_skylinks_from_airtable():
     )
 
     if airtable.status_code != 200:
-        message = "Airtable blocklist integration responded with code " + str(response.status_code) + ": " + (response.text or "empty response")
+        message = "Airtable blocklist integration responded with code " + str(airtable.status_code) + ": " + (airtable.text or "empty response")
         return print(message) and await send_msg(client, message, force_notify=False)
     
     skylinks = [entry['fields'][AIRTABLE_FIELD] for entry in airtable.json()['records']]

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -38,7 +38,7 @@ async def block_skylinks_from_airtable():
     response = requests.post('http://' + ipaddress + ':9980/skynet/blocklist', auth = auth, headers = headers, data = data)
     
     if response.status_code == 204:
-        print("Siad blocklist succesfully updated with provided skylink")
+        print("Siad blocklist successfully updated with provided skylink")
     else:
         message = "Siad blocklist endpoint responded with code " + str(response.status_code) + ": " + (response.text or "empty response")
         return print(message) or await send_msg(client, message, force_notify=True)

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -45,6 +45,14 @@ async def block_skylinks_from_airtable():
 
     print("Airtable returned total " + str(len(skylinks)) + " skylinks to block")
 
+    skylinks_returned = skylinks
+    skylinks = [skylink for skylink in skylinks if re.search("^[a-zA-Z0-9_-]{46}$", skylink)]
+
+    if len(skylinks_returned) != len(skylinks):
+        message = (skylinks_returned - len(skylinks)) + " of the skylinks returned from Airtable are not valid"
+        invalid_skylinks = [str(skylink) for skylink in list(set(skylinks_returned) - set(skylinks))]
+        print(message) or await send_msg(client, message, file=("\n".join(invalid_skylinks)))
+
     apipassword = exec("docker exec sia cat /sia-data/apipassword")
     ipaddress = exec("docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' sia")
 

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -43,7 +43,7 @@ async def block_skylinks_from_airtable():
         message = "Siad blocklist endpoint responded with code " + str(response.status_code) + ": " + (response.text or "empty response")
         return print(message) or await send_msg(client, message, force_notify=True)
 
-    print("Purging nginx cache containing blocked skylinks")
+    print("Searching nginx cache for blocked files")
     cached_files_command = '/usr/bin/find /data/nginx/cache/ -type f | /usr/bin/xargs --no-run-if-empty -n1000 /bin/grep -El \'^KEY: .*(' + '|'.join(skylinks) + ')\''
     cached_files_count = int(os.popen('docker exec -it nginx bash -c "' + cached_files_command + ' | wc -l"').read().strip())
 

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -6,75 +6,95 @@ from bot_utils import setup, send_msg
 bot_token = setup()
 client = discord.Client()
 
-AIRTABLE_API_KEY = os.getenv('AIRTABLE_API_KEY')
-AIRTABLE_BASE = os.getenv('AIRTABLE_BASE', 'app89plJvA9EqTJEc')
-AIRTABLE_TABLE = os.getenv('AIRTABLE_TABLE', 'Table%201')
-AIRTABLE_FIELD = os.getenv('AIRTABLE_FIELD', 'Link')
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+AIRTABLE_BASE = os.getenv("AIRTABLE_BASE", "app89plJvA9EqTJEc")
+AIRTABLE_TABLE = os.getenv("AIRTABLE_TABLE", "Table%201")
+AIRTABLE_FIELD = os.getenv("AIRTABLE_FIELD", "Link")
+
+
+def exec(command):
+    return os.popen(command).read().strip()
+
 
 async def block_skylinks_from_airtable():
-    print("Pulling blocked skylinks from airtable via api integration")
-    headers = { "Authorization": "Bearer " + AIRTABLE_API_KEY }
+    print("Pulling blocked skylinks from Airtable via api integration")
+    headers = {"Authorization": "Bearer " + AIRTABLE_API_KEY}
     skylinks = []
     offset = None
     while len(skylinks) == 0 or offset:
-        print("Requesting a batch of records from airtable with " + (offset if offset else "empty") + " offset")
-        query = '&'.join(['fields%5B%5D=' + AIRTABLE_FIELD, ('offset=' + offset) if offset else ''])
-        airtable = requests.get(
-            "https://api.airtable.com/v0/" + AIRTABLE_BASE + "/" + AIRTABLE_TABLE + "?" + query, headers=headers
+        print("Requesting a batch of records from Airtable with " + (offset if offset else "empty") + " offset")
+        query = "&".join(["fields%5B%5D=" + AIRTABLE_FIELD, ("offset=" + offset) if offset else ""])
+        response = requests.get(
+            "https://api.airtable.com/v0/" + AIRTABLE_BASE + "/" + AIRTABLE_TABLE + "?" + query,
+            headers=headers,
         )
 
-        if airtable.status_code != 200:
-            message = "Airtable blocklist integration responded with code " + str(airtable.status_code) + ": " + (airtable.text or "empty response")
+        if response.status_code != 200:
+            status_code = str(response.status_code)
+            response_text = response.text or "empty response"
+            message = "Airtable blocklist integration responded with code " + status_code + ": " + response_text
             return print(message) or await send_msg(client, message, force_notify=False)
-        
-        airtable_data = airtable.json()
-        skylinks = skylinks + [entry['fields'][AIRTABLE_FIELD] for entry in airtable_data['records']]
+
+        data = response.json()
+        skylinks = skylinks + [entry["fields"][AIRTABLE_FIELD] for entry in data["records"]]
 
         if len(skylinks) == 0:
             return print("Airtable returned 0 skylinks - make sure your configuration is correct")
-        
-        offset = airtable_data.get('offset')
-    
+
+        offset = data.get("offset")
+
     print("Airtable returned total " + str(len(skylinks)) + " skylinks to block")
-    
-    apipassword = os.popen('docker exec sia cat /sia-data/apipassword').read().strip()
-    ipaddress = os.popen('docker inspect -f \'{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}\' sia').read().strip()
-    
+
+    apipassword = exec("docker exec sia cat /sia-data/apipassword")
+    ipaddress = exec("docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' sia")
+
     print("Sending blocklist request to siad")
-    headers = { 'user-agent': 'Sia-Agent' }
-    auth = ('', apipassword)
-    data = json.dumps({ 'add': skylinks })
-    response = requests.post('http://' + ipaddress + ':9980/skynet/blocklist', auth = auth, headers = headers, data = data)
-    
+    response = requests.post(
+        "http://" + ipaddress + ":9980/skynet/blocklist",
+        auth=("", apipassword),
+        headers={"user-agent": "Sia-Agent"},
+        data=json.dumps({"add": skylinks}),
+    )
+
     if response.status_code == 204:
         print("Siad blocklist successfully updated with provided skylink")
     else:
-        message = "Siad blocklist endpoint responded with code " + str(response.status_code) + ": " + (response.text or "empty response")
+        status_code = str(response.status_code)
+        response_text = response.text or "empty response"
+        message = "Siad blocklist endpoint responded with code " + status_code + ": " + response_text
         return print(message) or await send_msg(client, message, force_notify=False)
 
     print("Searching nginx cache for blocked files")
-    cached_files_command = '/usr/bin/find /data/nginx/cache/ -type f | /usr/bin/xargs --no-run-if-empty -n1000 /bin/grep -Els \'^KEY: .*(' + '|'.join(skylinks) + ')\''
-    cached_files_count = int(os.popen('docker exec -it nginx bash -c "' + cached_files_command + ' | wc -l"').read().strip())
+    cached_files_command = (
+        "/usr/bin/find /data/nginx/cache/ -type f | /usr/bin/xargs --no-run-if-empty -n1000 /bin/grep -Els '^KEY: .*("
+        + "|".join(skylinks)
+        + ")'"
+    )
+    cached_files_count = int(exec('docker exec -it nginx bash -c "' + cached_files_command + ' | wc -l"'))
 
     if cached_files_count == 0:
         return print("No nginx cached files matching blocked skylinks were found")
 
-    os.popen('docker exec -it nginx bash -c "' + cached_files_command + ' | xargs rm"')
-    message = 'Purged ' + str(cached_files_count) + ' blocklisted files from nginx cache'
+    exec('docker exec -it nginx bash -c "' + cached_files_command + ' | xargs rm"')
+    message = "Purged " + str(cached_files_count) + " blocklisted files from nginx cache"
     return print(message) or await send_msg(client, message)
+
 
 async def exit_after(delay):
     await asyncio.sleep(delay)
     os._exit(0)
+
 
 @client.event
 async def on_ready():
     try:
         await block_skylinks_from_airtable()
     except:  # catch all exceptions
-        await send_msg(client, "```\n{}\n```".format(traceback.format_exc()), force_notify=False)
+        message = "```\n{}\n```".format(traceback.format_exc())
+        await send_msg(client, message, force_notify=False)
     asyncio.create_task(exit_after(3))
-    
+
+
 client.run(bot_token)
 
 # asyncio.run(on_ready())

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import os, asyncio, requests, json
+
+AIRTABLE_TABLE = "app89plJvA9EqTJEc"
+AIRTABLE_FIELD = "Link"
+
+async def block_skylinks_from_airtable():
+    headers = { "Authorization": "Bearer " + AIRTABLE_API_KEY }
+    airtable = requests.get(
+        "https://api.airtable.com/v0/" + AIRTABLE_TABLE + "/Table%201?fields%5B%5D=" + AIRTABLE_FIELD, headers=headers
+    ).json()
+    skylinks = [entry['fields'][AIRTABLE_FIELD] for entry in airtable['records']]
+    
+    apipassword = os.popen('docker exec sia cat /sia-data/apipassword').read().strip()
+    ipaddress = os.popen('docker inspect -f \'{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}\' sia').read().strip()
+    
+    headers = { 'user-agent': 'Sia-Agent' }
+    auth = ('', apipassword)
+    data = json.dumps({ 'add': skylinks })
+    response = requests.post('http://' + ipaddress + ':9980/skynet/blocklist', auth = auth, headers = headers, data = data)
+    
+    if response.status_code != 204:
+        message = "Blocklist responded with code " + str(response.status_code) + ": " + (response.text or "empty response")
+        print(message)
+
+async def exit_after(delay):
+    await asyncio.sleep(delay)
+    os._exit(0)
+
+async def on_ready():
+    await block_skylinks_from_airtable()
+    asyncio.create_task(exit_after(3))
+    
+asyncio.run(on_ready())
+
+# --- BASH EQUIVALENT
+# skylinks=$(curl "https://api.airtable.com/v0/${AIRTABLE_TABLE}/Table%201?fields%5B%5D=Link" -H "Authorization: Bearer ${AIRTABLE_KEY}" | python3 -c "import sys, json; print('[\"' + '\",\"'.join([entry['fields']['Link'] for entry in json.load(sys.stdin)['records']]) + '\"]')")
+# apipassword=$(docker exec sia cat /sia-data/apipassword)
+# ipaddress=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' sia)
+# curl -A "Sia-Agent" --user "":"${apipassword}" --data "{\"add\" : ${skylinks}}" "${ipaddress}:9980/skynet/blocklist"

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -19,7 +19,7 @@ async def block_skylinks_from_airtable():
 
     if airtable.status_code != 200:
         message = "Airtable blocklist integration responded with code " + str(airtable.status_code) + ": " + (airtable.text or "empty response")
-        return print(message) and await send_msg(client, message, force_notify=False)
+        return print(message) or await send_msg(client, message, force_notify=False)
     
     skylinks = [entry['fields'][AIRTABLE_FIELD] for entry in airtable.json()['records']]
     print("Airtable returned " + str(len(skylinks)) + " skylinks to block")
@@ -34,10 +34,10 @@ async def block_skylinks_from_airtable():
     response = requests.post('http://' + ipaddress + ':9980/skynet/blocklist', auth = auth, headers = headers, data = data)
     
     if response.status_code == 204:
-        print("Skylinks successfully added to siad blocklist")
+        return print("Skylinks successfully added to siad blocklist")
     else:
         message = "Siad blocklist endpoint responded with code " + str(response.status_code) + ": " + (response.text or "empty response")
-        await print(message) and send_msg(client, message, force_notify=False)
+        return await print(message) or send_msg(client, message, force_notify=False)
 
 async def exit_after(delay):
     await asyncio.sleep(delay)

--- a/setup-scripts/support/crontab
+++ b/setup-scripts/support/crontab
@@ -1,3 +1,4 @@
 0 0,8,16 * * * /home/user/skynet-webportal/setup-scripts/funds-checker.py /home/user/skynet-webportal/.env
 0 0,8,16 * * * /home/user/skynet-webportal/setup-scripts/log-checker.py /home/user/skynet-webportal/.env sia 8
 0 * * * * /home/user/skynet-webportal/setup-scripts/health-checker.py /home/user/skynet-webportal/.env sia 1
+30 */4 * * * /home/user/skynet-webportal/setup-scripts/blocklist-airtable.py /home/user/skynet-webportal/.env


### PR DESCRIPTION
adds integration to pull blocked skylinks from [airtable](https://airtable.com) and run the script in scheduled intervals

requires `AIRTABLE_API_KEY` in .env file


Tested on production server:

Debug output in case where files are matching:
> Pulling blocked skylinks from airtable via api integration
Requesting a batch of records from airtable with empty offset
Requesting a batch of records from airtable with itrI1mMyutaG9gj7M/recRQ2EOacEG1fhKd offset
Requesting a batch of records from airtable with itrI1mMyutaG9gj7M/recrRSLYPG8k0H9Yb offset
Airtable returned total 237 skylinks to block
Sending blocklist request to siad
Siad blocklist successfully updated with provided skylink
Searching nginx cache for blocked files
Purged 149 blocklisted files from nginx cache

Debug output in case where no files are matching:
> Pulling blocked skylinks from airtable via api integration
Requesting a batch of records from airtable with empty offset
Requesting a batch of records from airtable with itrI1mMyutaG9gj7M/recRQ2EOacEG1fhKd offset
Requesting a batch of records from airtable with itrI1mMyutaG9gj7M/recrRSLYPG8k0H9Yb offset
Airtable returned total 237 skylinks to block
Sending blocklist request to siad
Siad blocklist successfully updated with provided skylink
Searching nginx cache for blocked files
No nginx cached files matching blocked skylinks were found
