### PR TITLE
Allow credentials

### DIFF
--- a/docker/nginx/conf.d/include/cors
+++ b/docker/nginx/conf.d/include/cors
@@ -1,5 +1,6 @@
 if ($request_method = 'OPTIONS') {
-    more_set_headers 'Access-Control-Allow-Origin: *';
+    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Credentials: true';
     more_set_headers 'Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE';
     more_set_headers 'Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
     more_set_headers 'Access-Control-Max-Age: 1728000';
@@ -8,7 +9,8 @@ if ($request_method = 'OPTIONS') {
     return 204;
 }
 
-more_set_headers 'Access-Control-Allow-Origin: *';
+more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+more_set_headers 'Access-Control-Allow-Credentials: true';
 more_set_headers 'Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE';
 more_set_headers 'Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
 more_set_headers 'Access-Control-Expose-Headers: Content-Length,Content-Range,Skynet-File-Metadata,Skynet-Skylink,Skynet-Portal-Api';


### PR DESCRIPTION
Due to how accounts will work, we need to allow sending credentials with the request, otherwise we will get an error saying that we cannot include credentials when Access-Control-Allow-Origin is set to a wildcard.