### PR TITLE
Fix changing password

### DIFF
--- a/docker/kratos/config/identity.schema.json
+++ b/docker/kratos/config/identity.schema.json
@@ -28,7 +28,7 @@
         }
       },
       "required": ["email"],
-      "additionalProperties": false
+      "additionalProperties": true
     }
   }
 }

--- a/packages/dashboard/src/pages/auth/registration.js
+++ b/packages/dashboard/src/pages/auth/registration.js
@@ -50,20 +50,10 @@ const fieldsConfig = {
     autoComplete: "email",
     position: 0,
   },
-  "traits.name.first": {
-    label: "First name",
-    autoComplete: "given-name",
-    position: 1,
-  },
-  "traits.name.last": {
-    label: "Last name",
-    autoComplete: "family-name",
-    position: 2,
-  },
   password: {
     label: "Password",
     autoComplete: "new-password",
-    position: 4,
+    position: 1,
     checks: [
       {
         label: "At least 6 characters long",

--- a/packages/dashboard/src/pages/settings.js
+++ b/packages/dashboard/src/pages/settings.js
@@ -53,20 +53,10 @@ const fieldsConfig = {
     autoComplete: "email",
     position: 0,
   },
-  "traits.name.first": {
-    label: "First name",
-    autoComplete: "given-name",
-    position: 1,
-  },
-  "traits.name.last": {
-    label: "Last name",
-    autoComplete: "family-name",
-    position: 2,
-  },
   password: {
     label: "Password",
     autoComplete: "new-password",
-    position: 4,
+    position: 1,
   },
   csrf_token: {
     position: 99,

--- a/packages/dashboard/stubs/settings.json
+++ b/packages/dashboard/stubs/settings.json
@@ -34,9 +34,7 @@
             "required": true,
             "value": "i33iydUBN6jqwrkHlLPZ3ap7Ah4uC0UrTadn7zKT0jyouDpr+DF0/1Hbkshye9t7IKwyzOcLt7i6oR/OoEVg+g=="
           },
-          { "name": "traits.email", "type": "email", "value": "karol@nebulous.tech" },
-          { "name": "traits.name.first", "type": "text", "value": "Karol" },
-          { "name": "traits.name.last", "type": "text", "value": "Wypchło" }
+          { "name": "traits.email", "type": "email", "value": "karol@nebulous.tech" }
         ]
       }
     }
@@ -45,7 +43,7 @@
     "id": "ab776d6d-f324-4fa7-a728-7587d5215481",
     "schema_id": "default",
     "schema_url": "",
-    "traits": { "email": "karol@nebulous.tech", "name": { "first": "Karol", "last": "Wypchło" } }
+    "traits": { "email": "karol@nebulous.tech" }
   },
   "state": "show_form"
 }


### PR DESCRIPTION
## Issue

While we removed first and last name from the registration process, there are still may users who have those in their accounts. Once any of those users tried to change their passwords, the Dashboard form submits their names and email as well, resulting in an error because the name fields are not allowed.

## Solutions

1. We can manually scrub the names of all users with an SQL query. This should be relatively safe but not 100% - I haven't looked at all users and we have a good number now.
2. We can change the front end code to ignore the names and only use fields it knows about. I like this approach because it will be unaffected if other traits make their way into the user's account. I added a test trait and it mangled the UI making it unusable (writing in one field resulted in text appearing in another and so on). I can't easily do that change, though, because I don't really know the FE code.
3. Re-introduce the first and last name but don't use the during registration, users can choose to add them later. I'm not sure I like this a lot because users expressed frustration with the request to share their names during registration, even if it was optional.
4. Remove the name traits but allow additional traits during update. Thus users with names can update their passwords and their names. The downside is that the users with names won't be able to get rid of them and users without names won't be able to get them. Inconsistent.

This PR implements solution 4 because it was the fastest and safest for me to implement in order to deblock users.